### PR TITLE
Update ShellyTRV 'schedule.profile' to 'min: 0'

### DIFF
--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -165,7 +165,7 @@ const shellytrv = {
             'role': 'value',
             'read': true,
             'write': true,
-            'min': 1,
+            'min': 0,
             'max': 5,
         }
     },


### PR DESCRIPTION
Update ShellyTRV 'schedule.profile' to 'min: 0' because profile id can also be zero when schedule is disabled.