### PR TITLE
Change role for Energy related states

### DIFF
--- a/lib/shelly-helper.js
+++ b/lib/shelly-helper.js
@@ -619,7 +619,7 @@ function addSwitchToGen2Device(deviceObj, switchId, hasPowerMetering) {
             common: {
                 'name': 'Energy',
                 'type': 'number',
-                'role': 'value.power',
+                'role': 'value.power.consumption',
                 'read': true,
                 'write': false,
                 'def': 0,
@@ -1082,7 +1082,7 @@ function addCoverToGen2Device(deviceObj, coverId) {
         common: {
             'name': 'Energy',
             'type': 'number',
-            'role': 'value.power',
+            'role': 'value.power.consumption',
             'read': true,
             'write': false,
             'def': 0,


### PR DESCRIPTION
According to the ioBroker doc, the energy states should have role=value.power.consumption