### PR TITLE
add (expose) temperature_offset of shelly-trv as datapoint

### DIFF
--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -205,14 +205,14 @@ const shellytrv = {
         },
         mqtt: {
             http_publish: '/settings',
-            http_publish_funct: (value) => { return value ? JSON.parse(value).thermostats[0].temperature_offset.value : undefined; },
+            http_publish_funct: (value) => { return value ? JSON.parse(value).thermostats[0].temperature_offset : undefined; },
             http_cmd: '/settings/thermostat/0',
             http_cmd_funct: (value) => { return { temperature_offset: value }; },
         },
         common: {
             name: 'Temperature Offset',
             type: 'number',
-            role: 'level.temperature',
+            role: 'value.offset',
             read: true,
             write: true,
             unit: '°C',

--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -212,7 +212,7 @@ const shellytrv = {
         common: {
             name: 'Temperature Offset',
             type: 'number',
-            role: 'value.offset',
+            role: 'state',
             read: true,
             write: true,
             unit: '°C',

--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -199,7 +199,7 @@ const shellytrv = {
             unit: '°C',
         },
     },
-     'tmp.temperature_offset': {
+     'tmp.temperatureOffset': {
         coap: {
             coap_publish: '3103',
         },

--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -201,7 +201,7 @@ const shellytrv = {
             max: 31,
         },
     },
-     'tmp.temperatureOffset': {
+    'tmp.temperatureOffset': {
         coap: {
             coap_publish: '3103',
         },

--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -216,6 +216,8 @@ const shellytrv = {
             read: true,
             write: true,
             unit: '°C',
+            min: -9,
+            max: 9,
         },
     },
     'tmp.valvePosition': {

--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -197,6 +197,8 @@ const shellytrv = {
             read: true,
             write: true,
             unit: '°C',
+            min: 4,
+            max: 31,
         },
     },
      'tmp.temperatureOffset': {

--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -199,6 +199,25 @@ const shellytrv = {
             unit: '°C',
         },
     },
+     'tmp.temperature_offset': {
+        coap: {
+            coap_publish: '3103',
+        },
+        mqtt: {
+            http_publish: '/settings',
+            http_publish_funct: (value) => { return value ? JSON.parse(value).thermostats[0].temperature_offset.value : undefined; },
+            http_cmd: '/settings/thermostat/0',
+            http_cmd_funct: (value) => { return { temperature_offset: value }; },
+        },
+        common: {
+            name: 'Temperature Offset',
+            type: 'number',
+            role: 'level.temperature',
+            read: true,
+            write: true,
+            unit: '°C',
+        },
+    },
     'tmp.valvePosition': {
         coap: {
             coap_publish: '3102',


### PR DESCRIPTION
aligining shelly-trv with my other thermostats, which do all have a simple calibration option by statically correcting the locally measured temperature of the trv. Needed that to tweak my new heating setup :-)
Seems to work fine for me. 
sorry for the mess of commits...