### PR TITLE
added mini series

### DIFF
--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -52,6 +52,8 @@ const shellypro3em = require('./devices/gen2/shellypro3em').shellypro3em;
 const shellypro2cover = require('./devices/gen2/shellypro2cover').shellypro2cover;
 const shellyplusht = require('./devices/gen2/shellyplusht').shellyplusht;
 const shellyplusplugs = require('./devices/gen2/shellyplusplugs').shellyplusplugs;
+const shellyplus1mini = require('./devices/gen2/shellyplus1mini').shellyplus1mini;
+const shellyplus1pmmini = require('./devices/gen2/shellyplus1pmmini').shellyplus1pmmini;
 
 const devices = {
     // Gen 1
@@ -101,6 +103,8 @@ const devices = {
     shellypro2cover,
     shellyplusht,
     shellyplusplugs,
+    shellyplus1mini,
+    shellyplus1pmmini,
 };
 
 const deviceTypes = {
@@ -152,6 +156,8 @@ const deviceTypes = {
     shellypro2cover: ['shellypro2cover'],
     shellyplusht: ['shellyplusht'],
     shellyplusplugs: ['shellyplusplugs'],
+    shellyplus1mini: ['shellyplus1mini'],
+    shellyplus1pmmini: ['shellyplus1pmmini'],
 };
 
 const deviceGen = {
@@ -202,6 +208,8 @@ const deviceGen = {
     shellypro2cover: 2,
     shellyplusht: 2,
     shellyplusplugs: 2,
+    shellyplus1mini: 2,
+    shellyplus1pmmini: 2,
 };
 
 // https://shelly.cloud/knowledge-base/devices/
@@ -253,6 +261,8 @@ const deviceKnowledgeBase = {
     shellypro2cover: 'https://kb.shelly.cloud/knowledge-base/shelly-pro-dual-cover-pm',
     shellyplusht: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-h-t',
     shellyplusplugs: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-plug-s',
+    shellyplus1mini: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1-mini',
+    shellyplus1pmmini: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm-mini',
 };
 
 /**

--- a/lib/devices/gen2/shellyplus1mini.js
+++ b/lib/devices/gen2/shellyplus1mini.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const shellyHelperGen2 = require('../gen2-helper');
+
+/**
+ * Shelly Plus 1 Mini / shellyplus1mini
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1
+ */
+const shelly1mini = {
+
+};
+
+shellyHelperGen2.addSwitchToGen2Device(shelly1mini, 0, false);
+
+shellyHelperGen2.addInputToGen2Device(shelly1mini, 0);
+
+module.exports = {
+    shelly1mini,
+};

--- a/lib/devices/gen2/shellyplus1pmmini.js
+++ b/lib/devices/gen2/shellyplus1pmmini.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const shellyHelperGen2 = require('../gen2-helper');
+
+/**
+ * Shelly Plus 1 PM Mini / shellyplus1pmmini
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlus1PM
+ */
+const shelly1pmmini = {
+
+};
+
+shellyHelperGen2.addSwitchToGen2Device(shelly1pmmini, 0, true);
+
+shellyHelperGen2.addInputToGen2Device(shelly1pmmini, 0);
+
+module.exports = {
+    shelly1pmmini,
+};


### PR DESCRIPTION
added mini series (Shelly Plus 1 Mini + Shelly Plus 1 PM Mini).
please check if that was all the files I needed to create / edit - first time adding a new device type.
according to shelly support the mini series is literally 1:1 the same as the plus (from software) - the only difference is the relais itself which has a lower maximum power usage (2000W) compared to the "big" Plus (3500W)