### PR TITLE
Additions to Shelly Trv

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,13 @@ execute
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+
+### **WORK IN PROGRESS**
+
+* (theimo1221) More Shelly TRV Datapoints
+
 ### 6.4.5 (2023-09-26)
+
 * (klein0r) Added Shelly Pro Dual Cover/Shutter PM
 * (klein0r) Added Shelly Pro 3 EM 400A
 * (JuniperChris929) Added support of Shelly Plus 1 Mini + Shelly Plus 1 PM Mini

--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -368,6 +368,27 @@ const shellytrv = {
             write: true,
         },
     },
+    'ext.floorHeating': {
+        coap: {
+            http_publish: '/settings',
+            http_publish_funct: value => value ? JSON.parse(value).thermostats[0].ext_t.floor_heating : undefined,
+            http_cmd: '/settings/',
+            http_cmd_funct: value => ({ floor_heating: value ? 1 : 0 }),
+        },
+        mqtt: {
+            http_publish: '/settings',
+            http_publish_funct: value => value ? JSON.parse(value).thermostats[0].ext_t.floor_heating : undefined,
+            http_cmd: '/settings/',
+            http_cmd_funct: value => ({ floor_heating: value ? 1 : 0 }),
+        },
+        common: {
+            name: 'Under Floor heating mode',
+            type: 'boolean',
+            role: 'state',
+            read: true,
+            write: true,
+        },
+    },
     'ext.temperature': {
         coap: {
             http_cmd: '/ext_t',

--- a/lib/devices/gen1/shellytrv.js
+++ b/lib/devices/gen1/shellytrv.js
@@ -284,6 +284,30 @@ const shellytrv = {
             write: true,
         },
     },
+    'tmp.minimumValvePosition': {
+        coap: {
+            http_publish: '/settings',
+            http_publish_funct: value => value ? JSON.parse(value).thermostats[0].valve_min_percent : undefined,
+            http_cmd: '/settings/thermostat/0',
+            http_cmd_funct: value => ({ valve_min_percent: value }),
+        },
+        mqtt: {
+            http_publish: '/settings',
+            http_publish_funct: value => value ? JSON.parse(value).thermostats[0].valve_min_percent : undefined,
+            http_cmd: '/settings/thermostat/0',
+            http_cmd_funct: value => ({ valve_min_percent: value }),
+        },
+        common: {
+            name: 'Minimum Valve position',
+            type: 'number',
+            role: 'value.valve',
+            read: true,
+            write: true,
+            unit: '%',
+            min: 0,
+            max: 100,
+        },
+    },
     'tmp.valvePosition': {
         coap: {
             coap_publish: '3121',


### PR DESCRIPTION
Hello team,

today I added a Shelly TRV to my system and was missing following 2 datapoints in ioBroker, so I added them and testet it locally.

This adds the options:
- FloorHeating
- MinimumValvePosition

![image](https://github.com/iobroker-community-adapters/ioBroker.shelly/assets/20605452/404ddfb6-68f0-430f-87ec-a85387028bba)


Which are in the WebUi as well:
![image](https://github.com/iobroker-community-adapters/ioBroker.shelly/assets/20605452/7667b248-a9fe-4a95-9c5a-d982cb4b3291)
