### PR TITLE
Add Shelly Wall Display

### DIFF
--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -57,6 +57,7 @@ const shellyplusplugs = require('./devices/gen2/shellyplusplugs').shellyplusplug
 const shellypmmini = require('./devices/gen2/shellypmmini').shellypmmini;
 const shelly1mini = require('./devices/gen2/shelly1mini').shelly1mini;
 const shelly1pmmini = require('./devices/gen2/shelly1pmmini').shelly1pmmini;
+const shellywalldisplay = require('./devices/gen2/shellywalldisplay').shellywalldisplay;
 
 const devices = {
     // Gen 1
@@ -111,6 +112,7 @@ const devices = {
     shellypmmini,
     shelly1mini,
     shelly1pmmini,
+    shellywalldisplay,
 };
 
 const deviceTypes = {
@@ -167,6 +169,7 @@ const deviceTypes = {
     shellypmmini: ['shellypmmini'],
     shelly1mini: ['shelly1mini'],
     shelly1pmmini: ['shelly1pmmini'],
+    shellywalldisplay: ['shellywalldisplay'],
 };
 
 const deviceGen = {
@@ -222,6 +225,7 @@ const deviceGen = {
     shellypmmini: 2,
     shelly1mini: 2,
     shelly1pmmini: 2,
+    shellywalldisplay: 2,
 };
 
 // https://shelly.cloud/knowledge-base/devices/
@@ -278,6 +282,7 @@ const deviceKnowledgeBase = {
     shellypmmini: 'https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlusPMMini',
     shelly1mini: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1-mini',
     shelly1pmmini: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm-mini',
+    shellywalldisplay: 'Nicht vorhanden',
 };
 
 /**

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -7,7 +7,7 @@ const shellyHelper = require('../shelly-helper');
  * @param {object} deviceObj
  * @param {number} switchId
  */
-function addWallDisplay(deviceObj, switchId, sensorId) {
+function addWallDisplay(deviceObj, switchId) {
 
     deviceObj[`Relay${switchId}.Switch`] = {
         device_mode: 'switch',

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -7,6 +7,190 @@ const shellyHelper = require('../shelly-helper');
  * @param {object} deviceObj
  * @param {number} switchId
  */
+function addWallDisplay(deviceObj, switchId, sensorId) {
+
+    deviceObj[`Relay${switchId}.Switch`] = {
+        device_mode: 'switch',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).output,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.Set',
+                    params: {id: switchId, on: value},
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Switch',
+                de: 'Schalter',
+                ru: 'Переключить',
+                pt: 'Interruptor',
+                nl: 'Vertaling:',
+                fr: 'Interrupteur',
+                it: 'Interruttore',
+                es: 'Interruptor',
+                pl: 'Switch',
+                'zh-cn': '目 录',
+            },
+            type: 'boolean',
+            role: 'switch',
+            read: true,
+            write: true,
+            def: false,
+        },
+    };
+    deviceObj[`Relay${switchId}.InitialState`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).initial_state : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: {id: switchId, config: {initial_state: value}},
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Initial state',
+                de: 'Ausgangszustand',
+                ru: 'Начальное состояние',
+                pt: 'Estado inicial',
+                nl: 'Initiële staat',
+                fr: 'État initial',
+                it: 'Stato iniziale',
+                es: 'Estado inicial',
+                pl: 'Państwo inicjalne',
+                'zh-cn': '初次报告',
+            },
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: true,
+            states: {
+                'on': 'on',
+                'off': 'off',
+                'restore_last': 'restore_last',
+                'match_input': 'match_input',
+            },
+        },
+    };
+    deviceObj[`Relay${switchId}.AutoTimerOn`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).auto_on : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: {id: switchId, config: {auto_on: value}},
+                });
+            },
+        },
+        common: {
+            name: 'Auto Timer On',
+            type: 'boolean',
+            role: 'switch.enable',
+            def: false,
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.AutoTimerOnDelay`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).auto_on_delay : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: {id: switchId, config: {auto_on_delay: value}},
+                });
+            },
+        },
+        common: {
+            name: 'Auto Timer On Delay',
+            type: 'number',
+            role: 'level.timer',
+            def: 0,
+            unit: 's',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.AutoTimerOff`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).auto_off : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: {id: switchId, config: {auto_off: value}},
+                });
+            },
+        },
+        common: {
+            name: 'Auto Timer Off',
+            type: 'boolean',
+            role: 'switch.enable',
+            def: false,
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.AutoTimerOffDelay`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).auto_off_delay : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: {id: switchId, config: {auto_off_delay: value}},
+                });
+            },
+        },
+        common: {
+            name: 'Auto Timer Off Delay',
+            type: 'number',
+            role: 'level.timer',
+            def: 0,
+            unit: 's',
+            read: true,
+            write: true,
+        },
+    };
+}
+/**
+ * Adds a generic switch definition for gen 2 devices
+ * @param {object} deviceObj
+ * @param {number} switchId
+ */
 function addPM1ToGen2Device(deviceObj, switchId) {
 
 
@@ -1499,42 +1683,73 @@ function addTemperatureSensorToGen2Device(deviceObj, sensorId) {
             unit: '°F',
         },
     };
+}
+/**
+ * Adds a generic Illuminance sensor definition for gen 2 devices
+ * @param {object} deviceObj
+ * @param {number} sensorId
+ */
+function addIlluminanceSensorToGen2Device(deviceObj, sensorId) {
 
-    deviceObj[`Temperature${sensorId}.ReportThreshold`] = {
+    deviceObj[`Illuminance${sensorId}.ChannelName`] = {
         mqtt: {
-            http_publish: `/rpc/Temperature.GetConfig?id=${sensorId}`,
-            http_publish_funct: value => value ? JSON.parse(value).report_thr_C : undefined,
+            http_publish: `/rpc/Illuminance.GetConfig?id=${sensorId}`,
+            http_publish_funct: async (value, self) => {
+                return value ? await shellyHelper.setChannelName(self, `Illuminance${sensorId}`, JSON.parse(value).name) : undefined;
+            },
             mqtt_cmd: '<mqttprefix>/rpc',
             mqtt_cmd_funct: (value, self) => {
                 return JSON.stringify({
                     id: self.getNextMsgId(),
                     src: 'iobroker',
-                    method: 'Temperature.SetConfig',
-                    params: {id: sensorId, config: {report_thr_C: value}},
+                    method: 'Illuminance.SetConfig',
+                    params: {id: sensorId, config: {name: value}},
                 });
             },
         },
         common: {
             name: {
-                en: 'Report threshold',
-                de: 'Meldeschwelle',
-                ru: 'Порог отчета',
-                pt: 'Limiar de referência',
-                nl: 'Vertaling:',
-                fr: 'Limite du rapport',
-                it: 'Soglia di relazione',
-                es: 'Nivel de informe',
-                pl: 'Raport o progu',
-                'zh-cn': '报告阈值',
+                en: 'Channel name',
+                de: 'Kanalname',
+                ru: 'Имя канала',
+                pt: 'Nome do canal',
+                nl: 'Kanaalnaam',
+                fr: 'Nom du canal',
+                it: 'Nome del canale',
+                es: 'Nombre del canal',
+                pl: 'Channel imię',
+                'zh-cn': '姓名',
             },
-            type: 'number',
-            role: 'level.temperature',
+            type: 'string',
+            role: 'text',
             read: true,
             write: true,
-            unit: '°C',
-            def: 1,
-            min: 0.5,
-            max: 5,
+        },
+    };
+
+    deviceObj[`Illuminance${sensorId}.Lux`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/illuminance:${sensorId}`,
+            mqtt_publish_funct: value => JSON.parse(value).lux,
+        },
+        common: {
+            name: {
+                en: 'Illuminance',
+                de: 'Helligkeit',
+                ru: 'Освещенность',
+                pt: 'Iluminancia',
+                nl: 'Verlichtingssterkte',
+                fr: 'lumineuse',
+                it: 'Illuminazione',
+                es: 'Iluminancia',
+                pl: 'Podświetlenie',
+                'zh-cn': '照度',
+            },
+            type: 'number',
+            role: 'value.illuminance',
+            read: true,
+            write: false,
+            unit: 'lx',
         },
     };
 
@@ -2306,8 +2521,10 @@ module.exports = {
     addDevicePowerToGen2Device,
     addTemperatureSensorToGen2Device,
     addHumiditySensorToGen2Device,
+    addIlluminanceSensorToGen2Device,
     addEnergyMeterToGen2Device,
     addEnergyMeterDataToGen2Device,
     addPM1ToGen2Device,
     addPlusAddon,
+    addWallDisplay,
 };

--- a/lib/devices/gen2/shellywalldisplay.js
+++ b/lib/devices/gen2/shellywalldisplay.js
@@ -12,9 +12,9 @@ const shellywalldisplay = {
 };
 
 shellyHelperGen2.addWallDisplay(shellywalldisplay, 0, true);
-shellyHelperGen2.addHumiditySensorToGen2Device(shellywalldisplay,0)
-shellyHelperGen2.addTemperatureSensorToGen2Device(shellywalldisplay,0)
-shellyHelperGen2.addIlluminanceSensorToGen2Device(shellywalldisplay,0)
+shellyHelperGen2.addHumiditySensorToGen2Device(shellywalldisplay,0);
+shellyHelperGen2.addTemperatureSensorToGen2Device(shellywalldisplay,0);
+shellyHelperGen2.addIlluminanceSensorToGen2Device(shellywalldisplay,0);
 
 module.exports = {
     shellywalldisplay,

--- a/lib/devices/gen2/shellywalldisplay.js
+++ b/lib/devices/gen2/shellywalldisplay.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const shellyHelperGen2 = require('../gen2-helper');
+
+/**
+ * Shelly Wall Display / shellywalldisplay
+ *
+ * Aktuell keine Dokumentation vorhanden
+ */
+const shellywalldisplay = {
+
+};
+
+shellyHelperGen2.addWallDisplay(shellywalldisplay, 0, true);
+shellyHelperGen2.addHumiditySensorToGen2Device(shellywalldisplay,0)
+shellyHelperGen2.addTemperatureSensorToGen2Device(shellywalldisplay,0)
+shellyHelperGen2.addIlluminanceSensorToGen2Device(shellywalldisplay,0)
+
+module.exports = {
+    shellywalldisplay,
+};


### PR DESCRIPTION
Adding the Shelly Wall Display to the adapter.

The following values are read from the display:

- temperature
- humidity
- Illuminance

The relay can also be switched.

**Important:** By setting the http password on the Shelly Wall Displays web interface, the values are only transmitted once. For this reason, no password may be set. As a result, the following information appears permanently in the log: This device is not protected via restricted login (see adapter documentation for details)