### PR TITLE
added gen3 devices (1 mini and 1 pm mini gen3)

### DIFF
--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -1,308 +1,336 @@
-'use strict';
+"use strict";
 
 // Defaults
-const defaultsgen1 = require('./devices/default').defaultsgen1;
-const defaultsgen2 = require('./devices/default').defaultsgen2;
+const defaultsgen1 = require("./devices/default").defaultsgen1;
+const defaultsgen2 = require("./devices/default").defaultsgen2;
+const defaultsgen3 = require("./devices/default").defaultsgen3;
 
 // Gen 1
-const shelly1 = require('./devices/gen1/shelly1').shelly1;
-const shelly1pm = require('./devices/gen1/shelly1pm').shelly1pm;
-const shelly1l = require('./devices/gen1/shelly1l').shelly1l;
-const shellyswitch = require('./devices/gen1/shellyswitch').shellyswitch;
-const shellyswitch25 = require('./devices/gen1/shellyswitch25').shellyswitch25;
-const shellyht = require('./devices/gen1/shellyht').shellyht;
-const shellysmoke = require('./devices/gen1/shellysmoke').shellysmoke;
-const shellybulb = require('./devices/gen1/shellybulb').shellybulb;
-const shellyrgbw2 = require('./devices/gen1/shellyrgbw2').shellyrgbw2;
-const shelly2led = require('./devices/gen1/shelly2led').shelly2led;
-const shellyplug = require('./devices/gen1/shellyplug').shellyplug;
-const shellyplugs = require('./devices/gen1/shellyplugs').shellyplugs;
-const shelly4pro = require('./devices/gen1/shelly4pro').shelly4pro;
-const shellysense = require('./devices/gen1/shellysense').shellysense;
-const shellyem = require('./devices/gen1/shellyem').shellyem;
-const shellyem3 = require('./devices/gen1/shellyem3').shellyem3;
-const shellyflood = require('./devices/gen1/shellyflood').shellyflood;
-const shellydimmer = require('./devices/gen1/shellydimmer').shellydimmer;
-const shellydimmer2 = require('./devices/gen1/shellydimmer2').shellydimmer2;
-const shellydw = require('./devices/gen1/shellydw').shellydw;
-const shellydw2 = require('./devices/gen1/shellydw2').shellydw2;
-const shellybulbduo = require('./devices/gen1/shellybulbduo').shellybulbduo;
-const shellyvintage = require('./devices/gen1/shellyvintage').shellyvintage;
-const shellyix3 = require('./devices/gen1/shellyix3').shellyix3;
-const shellybutton1 = require('./devices/gen1/shellybutton1').shellybutton1;
-const shellygas = require('./devices/gen1/shellygas').shellygas;
-const shellyuni = require('./devices/gen1/shellyuni').shellyuni;
-const shellycolorbulb = require('./devices/gen1/shellycolorbulb').shellycolorbulb;
-const shellymotionsensor = require('./devices/gen1/shellymotionsensor').shellymotionsensor;
-const shellymotion2 = require('./devices/gen1/shellymotion2').shellymotion2;
-const shellytrv = require('./devices/gen1/shellytrv').shellytrv;
+const shelly1 = require("./devices/gen1/shelly1").shelly1;
+const shelly1pm = require("./devices/gen1/shelly1pm").shelly1pm;
+const shelly1l = require("./devices/gen1/shelly1l").shelly1l;
+const shellyswitch = require("./devices/gen1/shellyswitch").shellyswitch;
+const shellyswitch25 = require("./devices/gen1/shellyswitch25").shellyswitch25;
+const shellyht = require("./devices/gen1/shellyht").shellyht;
+const shellysmoke = require("./devices/gen1/shellysmoke").shellysmoke;
+const shellybulb = require("./devices/gen1/shellybulb").shellybulb;
+const shellyrgbw2 = require("./devices/gen1/shellyrgbw2").shellyrgbw2;
+const shelly2led = require("./devices/gen1/shelly2led").shelly2led;
+const shellyplug = require("./devices/gen1/shellyplug").shellyplug;
+const shellyplugs = require("./devices/gen1/shellyplugs").shellyplugs;
+const shelly4pro = require("./devices/gen1/shelly4pro").shelly4pro;
+const shellysense = require("./devices/gen1/shellysense").shellysense;
+const shellyem = require("./devices/gen1/shellyem").shellyem;
+const shellyem3 = require("./devices/gen1/shellyem3").shellyem3;
+const shellyflood = require("./devices/gen1/shellyflood").shellyflood;
+const shellydimmer = require("./devices/gen1/shellydimmer").shellydimmer;
+const shellydimmer2 = require("./devices/gen1/shellydimmer2").shellydimmer2;
+const shellydw = require("./devices/gen1/shellydw").shellydw;
+const shellydw2 = require("./devices/gen1/shellydw2").shellydw2;
+const shellybulbduo = require("./devices/gen1/shellybulbduo").shellybulbduo;
+const shellyvintage = require("./devices/gen1/shellyvintage").shellyvintage;
+const shellyix3 = require("./devices/gen1/shellyix3").shellyix3;
+const shellybutton1 = require("./devices/gen1/shellybutton1").shellybutton1;
+const shellygas = require("./devices/gen1/shellygas").shellygas;
+const shellyuni = require("./devices/gen1/shellyuni").shellyuni;
+const shellycolorbulb =
+  require("./devices/gen1/shellycolorbulb").shellycolorbulb;
+const shellymotionsensor =
+  require("./devices/gen1/shellymotionsensor").shellymotionsensor;
+const shellymotion2 = require("./devices/gen1/shellymotion2").shellymotion2;
+const shellytrv = require("./devices/gen1/shellytrv").shellytrv;
 
 // Gen 2
-const shellyplus1 = require('./devices/gen2/shellyplus1').shellyplus1;
-const shellyplus1pm = require('./devices/gen2/shellyplus1pm').shellyplus1pm;
-const shellyplus2pm = require('./devices/gen2/shellyplus2pm').shellyplus2pm;
-const shellyplusi4 = require('./devices/gen2/shellyplusi4').shellyplusi4;
-const shellypro1 = require('./devices/gen2/shellypro1').shellypro1;
-const shellypro1pm = require('./devices/gen2/shellypro1pm').shellypro1pm;
-const shellypro2 = require('./devices/gen2/shellypro2').shellypro2;
-const shellypro2pm = require('./devices/gen2/shellypro2pm').shellypro2pm;
-const shellypro3 = require('./devices/gen2/shellypro3').shellypro3;
-const shellypro4pm = require('./devices/gen2/shellypro4pm').shellypro4pm;
-const shellypro3em = require('./devices/gen2/shellypro3em').shellypro3em;
-const shellypro2cover = require('./devices/gen2/shellypro2cover').shellypro2cover;
-const shellyplusht = require('./devices/gen2/shellyplusht').shellyplusht;
-const shellyplussmoke = require('./devices/gen2/shellyplussmoke').shellyplussmoke;
-const shellyblugw = require('./devices/gen2/shellyblugw').shellyblugw;
-const shellyplusplugs = require('./devices/gen2/shellyplusplugs').shellyplusplugs;
-const shellypmmini = require('./devices/gen2/shellypmmini').shellypmmini;
-const shelly1mini = require('./devices/gen2/shelly1mini').shelly1mini;
-const shelly1pmmini = require('./devices/gen2/shelly1pmmini').shelly1pmmini;
-const shellywalldisplay = require('./devices/gen2/shellywalldisplay').shellywalldisplay;
+const shellyplus1 = require("./devices/gen2/shellyplus1").shellyplus1;
+const shellyplus1pm = require("./devices/gen2/shellyplus1pm").shellyplus1pm;
+const shellyplus2pm = require("./devices/gen2/shellyplus2pm").shellyplus2pm;
+const shellyplusi4 = require("./devices/gen2/shellyplusi4").shellyplusi4;
+const shellypro1 = require("./devices/gen2/shellypro1").shellypro1;
+const shellypro1pm = require("./devices/gen2/shellypro1pm").shellypro1pm;
+const shellypro2 = require("./devices/gen2/shellypro2").shellypro2;
+const shellypro2pm = require("./devices/gen2/shellypro2pm").shellypro2pm;
+const shellypro3 = require("./devices/gen2/shellypro3").shellypro3;
+const shellypro4pm = require("./devices/gen2/shellypro4pm").shellypro4pm;
+const shellypro3em = require("./devices/gen2/shellypro3em").shellypro3em;
+const shellypro2cover =
+  require("./devices/gen2/shellypro2cover").shellypro2cover;
+const shellyplusht = require("./devices/gen2/shellyplusht").shellyplusht;
+const shellyplussmoke =
+  require("./devices/gen2/shellyplussmoke").shellyplussmoke;
+const shellyblugw = require("./devices/gen2/shellyblugw").shellyblugw;
+const shellyplusplugs =
+  require("./devices/gen2/shellyplusplugs").shellyplusplugs;
+const shellypmmini = require("./devices/gen2/shellypmmini").shellypmmini;
+const shelly1mini = require("./devices/gen2/shelly1mini").shelly1mini;
+const shelly1pmmini = require("./devices/gen2/shelly1pmmini").shelly1pmmini;
+const shellywalldisplay =
+  require("./devices/gen2/shellywalldisplay").shellywalldisplay;
+
+// Gen 3
+const shellymini1g3 = require("./devices/gen3/shellymini1g3").shellymini1g3;
+const shelly1pmminig3 =
+  require("./devices/gen3/shelly1pmminig3").shelly1pmminig3;
 
 const devices = {
-    // Gen 1
-    shellyswitch,
-    shellyswitch25,
-    shelly1,
-    shelly1pm,
-    shelly1l,
-    shellyht,
-    shellysmoke,
-    shellybulb,
-    shellyrgbw2,
-    shelly2led,
-    shellyplug,
-    shelly4pro,
-    shellysense,
-    'shellyplug-s': shellyplugs,
-    shellyem,
-    shellyem3,
-    shellyflood,
-    shellydimmer,
-    shellydw,
-    shellydw2,
-    ShellyBulbDuo: shellybulbduo,
-    ShellyVintage: shellyvintage,
-    shellyix3,
-    shellybutton1,
-    shellygas,
-    shellydimmer2,
-    shellyuni,
-    shellycolorbulb,
-    shellymotionsensor,
-    shellymotion2,
-    shellytrv,
-    // Gen 2
-    shellyplus1,
-    shellyplus1pm,
-    shellyplus2pm,
-    shellyplusi4,
-    shellypro1,
-    shellypro1pm,
-    shellypro2,
-    shellypro2pm,
-    shellypro3,
-    shellypro4pm,
-    shellypro3em,
-    shellypro2cover,
-    shellyplusht,
-    shellyplussmoke,
-    shellyblugw,
-    shellyplusplugs,
-    shellypmmini,
-    shelly1mini,
-    shelly1pmmini,
-    shellywalldisplay,
+  // Gen 1
+  shellyswitch,
+  shellyswitch25,
+  shelly1,
+  shelly1pm,
+  shelly1l,
+  shellyht,
+  shellysmoke,
+  shellybulb,
+  shellyrgbw2,
+  shelly2led,
+  shellyplug,
+  shelly4pro,
+  shellysense,
+  "shellyplug-s": shellyplugs,
+  shellyem,
+  shellyem3,
+  shellyflood,
+  shellydimmer,
+  shellydw,
+  shellydw2,
+  ShellyBulbDuo: shellybulbduo,
+  ShellyVintage: shellyvintage,
+  shellyix3,
+  shellybutton1,
+  shellygas,
+  shellydimmer2,
+  shellyuni,
+  shellycolorbulb,
+  shellymotionsensor,
+  shellymotion2,
+  shellytrv,
+  // Gen 2
+  shellyplus1,
+  shellyplus1pm,
+  shellyplus2pm,
+  shellyplusi4,
+  shellypro1,
+  shellypro1pm,
+  shellypro2,
+  shellypro2pm,
+  shellypro3,
+  shellypro4pm,
+  shellypro3em,
+  shellypro2cover,
+  shellyplusht,
+  shellyplussmoke,
+  shellyblugw,
+  shellyplusplugs,
+  shellypmmini,
+  shelly1mini,
+  shelly1pmmini,
+  shellywalldisplay,
+  // Gen 3
+  shellymini1g3,
+  shelly1pmminig3,
 };
 
 const deviceTypes = {
-    // '<deviceClass>': ['<deviceType>', '<deviceType>'],
-    // Gen 1
-    shellyswitch: ['SHSW-21'],
-    shellyswitch25: ['SHSW-25'],
-    shelly1: ['SHSW-1'],
-    shelly1pm: ['SHSW-PM'],
-    shelly1l: ['SHSW-L'],
-    shellyht: ['SHHT-1'],
-    shellysmoke: ['SHSM-01'],
-    shellybulb: ['SHBLB-1'],
-    shellyrgbw2: ['SHRGBW2'],
-    shelly2led: ['SH2LED'],
-    shellyplug: ['SHPLG-1'],
-    shelly4pro: ['SHSW-44'],
-    shellysense: ['SHSEN-1'],
-    'shellyplug-s': ['SHPLG-S', 'SHPLG2-1'],
-    shellyem: ['SHEM'],
-    shellyem3: ['SHEM-3'],
-    shellyflood: ['SHWT-1'],
-    shellydimmer: ['SHDM-1'],
-    shellydw: ['SHDW-1'],
-    shellydw2: ['SHDW-2'],
-    ShellyBulbDuo: ['SHBDUO-1'],
-    ShellyVintage: ['SHVIN-1'],
-    shellyix3: ['SHIX3-1'],
-    shellybutton1: ['SHBTN-1', 'SHBTN-2'],
-    shellygas: ['SHGS-1'],
-    shellydimmer2: ['SHDM-2'],
-    shellyuni: ['SHUNI-1'],
-    shellycolorbulb: ['SHCB-1'],
-    shellymotionsensor: ['SHMOS-01'],
-    shellymotion2: ['SHMOS-02'],
-    shellytrv: ['SHTRV-01'],
-    // Gen 2
-    shellyplus1: ['shellyplus1'],
-    shellyplus1pm: ['shellyplus1pm'],
-    shellyplus2pm: ['shellyplus2pm'],
-    shellyplusi4: ['shellyplusi4'],
-    shellypro1: ['shellypro1'],
-    shellypro1pm: ['shellypro1pm'],
-    shellypro2: ['shellypro2'],
-    shellypro2pm: ['shellypro2pm'],
-    shellypro3: ['shellypro3'],
-    shellypro4pm: ['shellypro4pm'],
-    shellypro3em: ['shellypro3em', 'shellypro3em400'],
-    shellypro2cover: ['shellypro2cover'],
-    shellyplusht: ['shellyplusht'],
-    shellyplussmoke: ['shellyplussmoke'],
-    shellyblugw: ['shellyblugw'],
-    shellyplusplugs: ['shellyplusplugs'],
-    shellypmmini: ['shellypmmini'],
-    shelly1mini: ['shelly1mini'],
-    shelly1pmmini: ['shelly1pmmini'],
-    shellywalldisplay: ['ShellyWallDisplay'],
+  // '<deviceClass>': ['<deviceType>', '<deviceType>'],
+  // Gen 1
+  shellyswitch: ["SHSW-21"],
+  shellyswitch25: ["SHSW-25"],
+  shelly1: ["SHSW-1"],
+  shelly1pm: ["SHSW-PM"],
+  shelly1l: ["SHSW-L"],
+  shellyht: ["SHHT-1"],
+  shellysmoke: ["SHSM-01"],
+  shellybulb: ["SHBLB-1"],
+  shellyrgbw2: ["SHRGBW2"],
+  shelly2led: ["SH2LED"],
+  shellyplug: ["SHPLG-1"],
+  shelly4pro: ["SHSW-44"],
+  shellysense: ["SHSEN-1"],
+  "shellyplug-s": ["SHPLG-S", "SHPLG2-1"],
+  shellyem: ["SHEM"],
+  shellyem3: ["SHEM-3"],
+  shellyflood: ["SHWT-1"],
+  shellydimmer: ["SHDM-1"],
+  shellydw: ["SHDW-1"],
+  shellydw2: ["SHDW-2"],
+  ShellyBulbDuo: ["SHBDUO-1"],
+  ShellyVintage: ["SHVIN-1"],
+  shellyix3: ["SHIX3-1"],
+  shellybutton1: ["SHBTN-1", "SHBTN-2"],
+  shellygas: ["SHGS-1"],
+  shellydimmer2: ["SHDM-2"],
+  shellyuni: ["SHUNI-1"],
+  shellycolorbulb: ["SHCB-1"],
+  shellymotionsensor: ["SHMOS-01"],
+  shellymotion2: ["SHMOS-02"],
+  shellytrv: ["SHTRV-01"],
+  // Gen 2
+  shellyplus1: ["shellyplus1"],
+  shellyplus1pm: ["shellyplus1pm"],
+  shellyplus2pm: ["shellyplus2pm"],
+  shellyplusi4: ["shellyplusi4"],
+  shellypro1: ["shellypro1"],
+  shellypro1pm: ["shellypro1pm"],
+  shellypro2: ["shellypro2"],
+  shellypro2pm: ["shellypro2pm"],
+  shellypro3: ["shellypro3"],
+  shellypro4pm: ["shellypro4pm"],
+  shellypro3em: ["shellypro3em", "shellypro3em400"],
+  shellypro2cover: ["shellypro2cover"],
+  shellyplusht: ["shellyplusht"],
+  shellyplussmoke: ["shellyplussmoke"],
+  shellyblugw: ["shellyblugw"],
+  shellyplusplugs: ["shellyplusplugs"],
+  shellypmmini: ["shellypmmini"],
+  shelly1mini: ["shelly1mini"],
+  shelly1pmmini: ["shelly1pmmini"],
+  shellywalldisplay: ["ShellyWallDisplay"],
+  // Gen 3
+  shellymini1g3: ["shellymini1g3"],
+  shelly1pmminig3: ["shelly1pmminig3"],
 };
 
 const deviceGen = {
-    // Gen 1
-    shellyswitch: 1,
-    shellyswitch25: 1,
-    shelly1: 1,
-    shelly1pm: 1,
-    shelly1l: 1,
-    shellyht: 1,
-    shellysmoke: 1,
-    shellybulb: 1,
-    shellyrgbw2: 1,
-    shelly2led: 1,
-    shellyplug: 1,
-    shelly4pro: 1,
-    shellysense: 1,
-    'shellyplug-s': 1,
-    shellyem: 1,
-    shellyem3: 1,
-    shellyflood: 1,
-    shellydimmer: 1,
-    shellydw: 1,
-    shellydw2: 1,
-    ShellyBulbDuo: 1,
-    ShellyVintage: 1,
-    shellyix3: 1,
-    shellybutton1: 1,
-    shellygas: 1,
-    shellydimmer2: 1,
-    shellyuni: 1,
-    shellycolorbulb: 1,
-    shellymotionsensor: 1,
-    shellymotion2: 1,
-    shellytrv: 1,
-    // Gen 2
-    shellyplus1: 2,
-    shellyplus1pm: 2,
-    shellyplus2pm: 2,
-    shellyplusi4: 2,
-    shellypro1: 2,
-    shellypro1pm: 2,
-    shellypro2: 2,
-    shellypro2pm: 2,
-    shellypro3: 2,
-    shellypro4pm: 2,
-    shellypro3em: 2,
-    shellypro2cover: 2,
-    shellyplusht: 2,
-    shellyplussmoke: 2,
-    shellyblugw: 2,
-    shellyplusplugs: 2,
-    shellypmmini: 2,
-    shelly1mini: 2,
-    shelly1pmmini: 2,
-    shellywalldisplay: 2,
+  // Gen 1
+  shellyswitch: 1,
+  shellyswitch25: 1,
+  shelly1: 1,
+  shelly1pm: 1,
+  shelly1l: 1,
+  shellyht: 1,
+  shellysmoke: 1,
+  shellybulb: 1,
+  shellyrgbw2: 1,
+  shelly2led: 1,
+  shellyplug: 1,
+  shelly4pro: 1,
+  shellysense: 1,
+  "shellyplug-s": 1,
+  shellyem: 1,
+  shellyem3: 1,
+  shellyflood: 1,
+  shellydimmer: 1,
+  shellydw: 1,
+  shellydw2: 1,
+  ShellyBulbDuo: 1,
+  ShellyVintage: 1,
+  shellyix3: 1,
+  shellybutton1: 1,
+  shellygas: 1,
+  shellydimmer2: 1,
+  shellyuni: 1,
+  shellycolorbulb: 1,
+  shellymotionsensor: 1,
+  shellymotion2: 1,
+  shellytrv: 1,
+  // Gen 2
+  shellyplus1: 2,
+  shellyplus1pm: 2,
+  shellyplus2pm: 2,
+  shellyplusi4: 2,
+  shellypro1: 2,
+  shellypro1pm: 2,
+  shellypro2: 2,
+  shellypro2pm: 2,
+  shellypro3: 2,
+  shellypro4pm: 2,
+  shellypro3em: 2,
+  shellypro2cover: 2,
+  shellyplusht: 2,
+  shellyplussmoke: 2,
+  shellyblugw: 2,
+  shellyplusplugs: 2,
+  shellypmmini: 2,
+  shelly1mini: 2,
+  shelly1pmmini: 2,
+  shellywalldisplay: 2,
+  // Gen 3
+  shellymini1g3: 3,
+  shelly1pmminig3: 3,
 };
 
 // https://shelly.cloud/knowledge-base/devices/
 const deviceKnowledgeBase = {
-    // Gen 1
-    shellyswitch: undefined,
-    shellyswitch25: 'https://kb.shelly.cloud/knowledge-base/shelly-2-5',
-    shelly1: 'https://kb.shelly.cloud/knowledge-base/shelly-1',
-    shelly1pm: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm',
-    shelly1l: 'https://kb.shelly.cloud/knowledge-base/shelly-1l',
-    shellyht: 'https://kb.shelly.cloud/knowledge-base/shelly-h-t',
-    shellysmoke: undefined,
-    shellybulb: undefined,
-    shellyrgbw2: 'https://kb.shelly.cloud/knowledge-base/shelly-rgbw2',
-    shelly2led: undefined,
-    shellyplug: 'https://kb.shelly.cloud/knowledge-base/shelly-plug',
-    shelly4pro: 'https://kb.shelly.cloud/knowledge-base/4shelly-pro-4pm',
-    shellysense: undefined,
-    'shellyplug-s': 'https://kb.shelly.cloud/knowledge-base/shelly-plug-s',
-    shellyem: 'https://kb.shelly.cloud/knowledge-base/shelly-em',
-    shellyem3: 'https://kb.shelly.cloud/knowledge-base/shelly-3em',
-    shellyflood: 'https://kb.shelly.cloud/knowledge-base/shelly-flood',
-    shellydimmer: undefined,
-    shellydw: undefined,
-    shellydw2: 'https://kb.shelly.cloud/knowledge-base/shelly-door-window-2',
-    ShellyBulbDuo: 'https://kb.shelly.cloud/knowledge-base/shelly-bulb-duo-rgbw',
-    ShellyVintage: 'https://kb.shelly.cloud/knowledge-base/shelly-vintage',
-    shellyix3: 'https://kb.shelly.cloud/knowledge-base/shelly-i3',
-    shellybutton1: 'https://kb.shelly.cloud/knowledge-base/shelly-button-1',
-    shellygas: 'https://kb.shelly.cloud/knowledge-base/shelly-gas',
-    shellydimmer2: 'https://kb.shelly.cloud/knowledge-base/shelly-dimmer-2',
-    shellyuni: 'https://kb.shelly.cloud/knowledge-base/shelly-uni',
-    shellycolorbulb: undefined,
-    shellymotionsensor: 'https://kb.shelly.cloud/knowledge-base/shelly-motion',
-    shellymotion2: 'https://kb.shelly.cloud/knowledge-base/shelly-motion-2',
-    shellytrv: 'https://kb.shelly.cloud/knowledge-base/shelly-trv',
-    // Gen 2
-    shellyplus1: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1',
-    shellyplus1pm: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm',
-    shellyplus2pm: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-2pm',
-    shellyplusi4: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-i4',
-    shellypro1: 'https://kb.shelly.cloud/knowledge-base/shelly-pro-1',
-    shellypro1pm: 'https://kb.shelly.cloud/knowledge-base/shelly-pro-1pm',
-    shellypro2: 'https://kb.shelly.cloud/knowledge-base/shelly-pro-2',
-    shellypro2pm: 'https://kb.shelly.cloud/knowledge-base/shelly-pro-2pm',
-    shellypro3: 'https://kb.shelly.cloud/knowledge-base/shelly-pro-3-v1',
-    shellypro4pm: 'https://kb.shelly.cloud/knowledge-base/4shelly-pro-4pm',
-    shellypro3em: 'https://kb.shelly.cloud/knowledge-base/shelly-pro-3em',
-    shellypro2cover: 'https://kb.shelly.cloud/knowledge-base/shelly-pro-dual-cover-pm',
-    shellyplusht: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-h-t',
-    shellyplussmoke: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-smoke',
-    shellyblugw: 'https://kb.shelly.cloud/knowledge-base/shellyblu-gateway',
-    shellyplusplugs: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-plug-s',
-    shellypmmini: 'https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlusPMMini',
-    shelly1mini: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1-mini',
-    shelly1pmmini: 'https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm-mini',
-    shellywalldisplay: 'https://kb.shelly.cloud/knowledge-base/shelly-wall-display',
+  // Gen 1
+  shellyswitch: undefined,
+  shellyswitch25: "https://kb.shelly.cloud/knowledge-base/shelly-2-5",
+  shelly1: "https://kb.shelly.cloud/knowledge-base/shelly-1",
+  shelly1pm: "https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm",
+  shelly1l: "https://kb.shelly.cloud/knowledge-base/shelly-1l",
+  shellyht: "https://kb.shelly.cloud/knowledge-base/shelly-h-t",
+  shellysmoke: undefined,
+  shellybulb: undefined,
+  shellyrgbw2: "https://kb.shelly.cloud/knowledge-base/shelly-rgbw2",
+  shelly2led: undefined,
+  shellyplug: "https://kb.shelly.cloud/knowledge-base/shelly-plug",
+  shelly4pro: "https://kb.shelly.cloud/knowledge-base/4shelly-pro-4pm",
+  shellysense: undefined,
+  "shellyplug-s": "https://kb.shelly.cloud/knowledge-base/shelly-plug-s",
+  shellyem: "https://kb.shelly.cloud/knowledge-base/shelly-em",
+  shellyem3: "https://kb.shelly.cloud/knowledge-base/shelly-3em",
+  shellyflood: "https://kb.shelly.cloud/knowledge-base/shelly-flood",
+  shellydimmer: undefined,
+  shellydw: undefined,
+  shellydw2: "https://kb.shelly.cloud/knowledge-base/shelly-door-window-2",
+  ShellyBulbDuo: "https://kb.shelly.cloud/knowledge-base/shelly-bulb-duo-rgbw",
+  ShellyVintage: "https://kb.shelly.cloud/knowledge-base/shelly-vintage",
+  shellyix3: "https://kb.shelly.cloud/knowledge-base/shelly-i3",
+  shellybutton1: "https://kb.shelly.cloud/knowledge-base/shelly-button-1",
+  shellygas: "https://kb.shelly.cloud/knowledge-base/shelly-gas",
+  shellydimmer2: "https://kb.shelly.cloud/knowledge-base/shelly-dimmer-2",
+  shellyuni: "https://kb.shelly.cloud/knowledge-base/shelly-uni",
+  shellycolorbulb: undefined,
+  shellymotionsensor: "https://kb.shelly.cloud/knowledge-base/shelly-motion",
+  shellymotion2: "https://kb.shelly.cloud/knowledge-base/shelly-motion-2",
+  shellytrv: "https://kb.shelly.cloud/knowledge-base/shelly-trv",
+  // Gen 2
+  shellyplus1: "https://kb.shelly.cloud/knowledge-base/shelly-plus-1",
+  shellyplus1pm: "https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm",
+  shellyplus2pm: "https://kb.shelly.cloud/knowledge-base/shelly-plus-2pm",
+  shellyplusi4: "https://kb.shelly.cloud/knowledge-base/shelly-plus-i4",
+  shellypro1: "https://kb.shelly.cloud/knowledge-base/shelly-pro-1",
+  shellypro1pm: "https://kb.shelly.cloud/knowledge-base/shelly-pro-1pm",
+  shellypro2: "https://kb.shelly.cloud/knowledge-base/shelly-pro-2",
+  shellypro2pm: "https://kb.shelly.cloud/knowledge-base/shelly-pro-2pm",
+  shellypro3: "https://kb.shelly.cloud/knowledge-base/shelly-pro-3-v1",
+  shellypro4pm: "https://kb.shelly.cloud/knowledge-base/4shelly-pro-4pm",
+  shellypro3em: "https://kb.shelly.cloud/knowledge-base/shelly-pro-3em",
+  shellypro2cover:
+    "https://kb.shelly.cloud/knowledge-base/shelly-pro-dual-cover-pm",
+  shellyplusht: "https://kb.shelly.cloud/knowledge-base/shelly-plus-h-t",
+  shellyplussmoke: "https://kb.shelly.cloud/knowledge-base/shelly-plus-smoke",
+  shellyblugw: "https://kb.shelly.cloud/knowledge-base/shellyblu-gateway",
+  shellyplusplugs: "https://kb.shelly.cloud/knowledge-base/shelly-plus-plug-s",
+  shellypmmini:
+    "https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyPlusPMMini",
+  shelly1mini: "https://kb.shelly.cloud/knowledge-base/shelly-plus-1-mini",
+  shelly1pmmini: "https://kb.shelly.cloud/knowledge-base/shelly-plus-1pm-mini",
+  shellywalldisplay:
+    "https://kb.shelly.cloud/knowledge-base/shelly-wall-display",
+  // Gen 3
+  shellymini1g3: "https://kb.shelly.cloud/knowledge-base/shelly-1-mini-gen3",
+  shelly1pmminig3:
+    "https://kb.shelly.cloud/knowledge-base/shelly-1pm-mini-gen3",
 };
 
 /**
  * Poll time of battery-powered devices (sec)
  */
 const pollTime = {
-    // Gen 1
-    shellyht: 3600,
-    shellysmoke: 3600,
-    shellysense: 3600,
-    shellyflood: 3600,
-    shellydw: 3600,
-    shellydw2: 3600,
-    shellybutton1: 3600,
-    shellygas: 3600,
-    shellymotionsensor: 3600,
-    shellymotion2: 3600,
-    // Gen 2
-    shellyplusht: 3600,
-    shellyplussmoke: 3600,
+  // Gen 1
+  shellyht: 3600,
+  shellysmoke: 3600,
+  shellysense: 3600,
+  shellyflood: 3600,
+  shellydw: 3600,
+  shellydw2: 3600,
+  shellybutton1: 3600,
+  shellygas: 3600,
+  shellymotionsensor: 3600,
+  shellymotion2: 3600,
+  // Gen 2
+  shellyplusht: 3600,
+  shellyplussmoke: 3600,
 };
 
 /**
@@ -310,102 +338,108 @@ const pollTime = {
  * @param {*} obj
  */
 function clone(obj) {
-    if (obj === null || typeof (obj) !== 'object' || 'isActiveClone' in obj) {
-        return obj;
-    }
+  if (obj === null || typeof obj !== "object" || "isActiveClone" in obj) {
+    return obj;
+  }
 
-    let temp;
-    if (obj instanceof Date) {
-        temp = new obj.constructor(); // or new Date(obj);
-    } else {
-        temp = obj.constructor();
-    }
+  let temp;
+  if (obj instanceof Date) {
+    temp = new obj.constructor(); // or new Date(obj);
+  } else {
+    temp = obj.constructor();
+  }
 
-    for (const key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-            obj['isActiveClone'] = null;
-            temp[key] = clone(obj[key]);
-            delete obj['isActiveClone'];
-        }
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      obj["isActiveClone"] = null;
+      temp[key] = clone(obj[key]);
+      delete obj["isActiveClone"];
     }
+  }
 
-    return temp;
+  return temp;
 }
 
 function deleteNoDisplay(device, protocol, mode) {
-    if (protocol === 'coap' || protocol === 'mqtt') {
-        for (const key in device) {
-            const dev = device[key];
-            if (dev?.[protocol]?.no_display) {
-                delete device[key];
-                continue;
-            }
+  if (protocol === "coap" || protocol === "mqtt") {
+    for (const key in device) {
+      const dev = device[key];
+      if (dev?.[protocol]?.no_display) {
+        delete device[key];
+        continue;
+      }
 
-            // Device Mode - just filter if mode is configured!
-            if (mode && dev?.device_mode) {
-                if (dev.device_mode !== mode) {
-                    delete device[key];
-                }
-            }
+      // Device Mode - just filter if mode is configured!
+      if (mode && dev?.device_mode) {
+        if (dev.device_mode !== mode) {
+          delete device[key];
         }
+      }
     }
+  }
 
-    return device;
+  return device;
 }
 
 function getDeviceByClass(deviceClass, protocol, mode) {
-    if (!devices[deviceClass]) return;
+  if (!devices[deviceClass]) return;
 
-    let device;
+  let device;
 
-    if (getDeviceGen(deviceClass) === 2) {
-        device = clone(Object.assign(devices[deviceClass], defaultsgen2));
-    } else {
-        device = clone(Object.assign(devices[deviceClass], defaultsgen1));
-    }
+  if (getDeviceGen(deviceClass) === 3) {
+    device = clone(Object.assign(devices[deviceClass], defaultsgen3));
+  } else if (getDeviceGen(deviceClass) === 2) {
+    device = clone(Object.assign(devices[deviceClass], defaultsgen2));
+  } else {
+    device = clone(Object.assign(devices[deviceClass], defaultsgen1));
+  }
 
-    device = deleteNoDisplay(device, protocol, mode);
-    return device;
+  device = deleteNoDisplay(device, protocol, mode);
+  return device;
 }
 
 function getDeviceTypeByClass(deviceClass) {
-    return deviceTypes[deviceClass] ? deviceTypes[deviceClass][0] : undefined;
+  return deviceTypes[deviceClass] ? deviceTypes[deviceClass][0] : undefined;
 }
 
 function getDeviceClassByType(deviceType) {
-    return Object.keys(deviceTypes).find((key) => deviceTypes[key].indexOf(deviceType) !== -1);
+  return Object.keys(deviceTypes).find(
+    (key) => deviceTypes[key].indexOf(deviceType) !== -1
+  );
 }
 
 function getKnowledgeBaseUrlByClass(deviceClass) {
-    return deviceKnowledgeBase?.[deviceClass];
+  return deviceKnowledgeBase?.[deviceClass];
 }
 
 function getAllDeviceDefinitions() {
-    return Object.entries(devices).reduce((o, [deviceClass, device]) => {
-        if (getDeviceGen(deviceClass) === 2) {
-            o[deviceClass] = clone(Object.assign(device, defaultsgen2));
-        } else {
-            o[deviceClass] = clone(Object.assign(device, defaultsgen1));
-        }
+  return Object.entries(devices).reduce((o, [deviceClass, device]) => {
+    if (getDeviceGen(deviceClass) === 3) {
+      o[deviceClass] = clone(Object.assign(device, defaultsgen3));
+    } else if (getDeviceGen(deviceClass) === 2) {
+      o[deviceClass] = clone(Object.assign(device, defaultsgen2));
+    } else {
+      o[deviceClass] = clone(Object.assign(device, defaultsgen1));
+    }
 
-        return o;
-    }, {});
+    return o;
+  }, {});
 }
 
 function getDeviceGen(deviceClass) {
-    return deviceGen[deviceClass] ? deviceGen[deviceClass] : 1;
+  return deviceGen[deviceClass] ? deviceGen[deviceClass] : 1;
 }
 
 function getPolltime(deviceClass) {
-    return pollTime?.[deviceClass];
+  return pollTime?.[deviceClass];
 }
 
 module.exports = {
-    getDeviceTypeByClass,
-    getDeviceClassByType,
-    getAllDeviceDefinitions,
-    getKnowledgeBaseUrlByClass,
-    getDeviceGen,
-    getDeviceByClass,
-    getPolltime,
+  getDeviceTypeByClass,
+  getDeviceClassByType,
+  getAllDeviceDefinitions,
+  getKnowledgeBaseUrlByClass,
+  getDeviceGen,
+  getDeviceByClass,
+  getPolltime,
 };

--- a/lib/devices/default.js
+++ b/lib/devices/default.js
@@ -1,736 +1,771 @@
-'use strict';
+"use strict";
 
-const shellyHelper = require('../shelly-helper');
+const shellyHelper = require("../shelly-helper");
 
 /**
  * Default, used for all Shelly devices Gen 1
  * https://shelly-api-docs.shelly.cloud/gen1/
  */
 const defaultsgen1 = {
-    'gen': {
-        coap: {
-            init_funct: self => self.getDeviceGen(),
-        },
-        mqtt: {
-            init_funct: self => self.getDeviceGen(),
-        },
-        common: {
-            name: {
-                en: 'Device generation',
-                de: 'Gerätegeneration',
-                ru: 'Генерация устройства',
-                pt: 'Geração de dispositivos',
-                nl: 'Vernietigingsgeneratie',
-                fr: 'Production d\'appareils',
-                it: 'Generazione di dispositivi',
-                es: 'Generación de dispositivos',
-                pl: 'Pokolenie Device',
-                uk: 'Виробництво',
-                'zh-cn': '代 人',
-            },
-            type: 'number',
-            role: 'state',
-            read: true,
-            write: false,
-            states: {
-                1: 'Generation 1',
-                2: 'Generation 2',
-            },
-        },
+  gen: {
+    coap: {
+      init_funct: (self) => self.getDeviceGen(),
     },
-    'online': {
-        coap: {
-            init_funct: self => self.isOnline(),
-        },
-        mqtt: {
-            init_funct: self => self.isOnline(),
-        },
-        common: {
-            name: {
-                en: 'Device online',
-                de: 'Gerät online',
-                ru: 'Устройство онлайн',
-                pt: 'Dispositivo online',
-                nl: 'Device online',
-                fr: 'Appareil en ligne',
-                it: 'Dispositivo online',
-                es: 'Dispositivo en línea',
-                pl: 'Device online',
-                uk: 'Пристрої онлайн',
-                'zh-cn': '网上证人',
-            },
-            type: 'boolean',
-            role: 'indicator.reachable',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('wifi'),
-        },
+    mqtt: {
+      init_funct: (self) => self.getDeviceGen(),
     },
-    'firmware': {
-        coap: {
-            http_publish: '/status',
-            http_publish_funct: value => value ? JSON.parse(value).update.has_update : undefined,
-        },
-        mqtt: {
-            http_publish: '/status',
-            http_publish_funct: value => value ? JSON.parse(value).update.has_update : undefined,
-        },
-        common: {
-            name: {
-                en: 'New firmware available',
-                de: 'Neue Firmware verfügbar',
-                ru: 'Новая прошивка доступна',
-                pt: 'Novo firmware disponível',
-                nl: 'Nieuwe firmaware',
-                fr: 'Nouveau firmware disponible',
-                it: 'Nuovo firmware disponibile',
-                es: 'Nuevo firmware disponible',
-                pl: 'Nowy sprzęt',
-                uk: 'Нова прошивка доступна',
-                'zh-cn': '新的警觉',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+    common: {
+      name: {
+        en: "Device generation",
+        de: "Gerätegeneration",
+        ru: "Генерация устройства",
+        pt: "Geração de dispositivos",
+        nl: "Vernietigingsgeneratie",
+        fr: "Production d'appareils",
+        it: "Generazione di dispositivi",
+        es: "Generación de dispositivos",
+        pl: "Pokolenie Device",
+        uk: "Виробництво",
+        "zh-cn": "代 人",
+      },
+      type: "number",
+      role: "state",
+      read: true,
+      write: false,
+      states: {
+        1: "Generation 1",
+        2: "Generation 2",
+        3: "Generation 3",
+      },
     },
-    'firmwareupdate': {
-        coap: {
-            http_cmd: '/ota?update=true',
-        },
-        mqtt: {
-            http_cmd: '/ota?update=true',
-        },
-        common: {
-            name: {
-                en: 'Update firmware version',
-                de: 'Firmware-Version aktualisieren',
-                ru: 'Обновление версии прошивки',
-                pt: 'Atualizar versão de firmware',
-                nl: 'Update firmaware',
-                fr: 'Update firmware version',
-                it: 'Versione firmware di aggiornamento',
-                es: 'Actualizar la versión de firmware',
-                pl: 'Oficjalna strona',
-                uk: 'Оновлення версії прошивки',
-                'zh-cn': '最新软件版本',
-            },
-            type: 'boolean',
-            role: 'button',
-            read: false,
-            write: true,
-            icon: shellyHelper.getIcon('update'),
-        },
+  },
+  online: {
+    coap: {
+      init_funct: (self) => self.isOnline(),
     },
-    'uptime': {
-        coap: {
-            http_publish: '/status',
-            http_publish_funct: value => value ? parseInt(JSON.parse(value).uptime) : undefined,
-        },
-        mqtt: {
-            http_publish: '/status',
-            http_publish_funct: value => value ? parseInt(JSON.parse(value).uptime) : undefined,
-        },
-        common: {
-            name: {
-                en: 'Device running since',
-                de: 'Gerät läuft seit',
-                ru: 'Устройство работает с',
-                pt: 'Dispositivo em execução desde',
-                nl: 'Device vlucht sinds',
-                fr: 'Appareils fonctionnant depuis',
-                it: 'Dispositivo in esecuzione da',
-                es: 'Dispositivo funcionando desde',
-                pl: 'Device biegnie od czasu do czasu',
-                uk: 'Пристрої, що працюють з',
-                'zh-cn': '自那时以来丧失能力',
-            },
-            type: 'number',
-            role: 'value.interval',
-            unit: 'sec',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('clock'),
-        },
+    mqtt: {
+      init_funct: (self) => self.isOnline(),
     },
-    'version': {
-        coap: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).fw : undefined,
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).fw : undefined,
-        },
-        common: {
-            name: {
-                en: 'Firmware version',
-                de: 'Firmware-Version',
-                ru: 'Версия прошивки',
-                pt: 'Versão de firmware',
-                nl: 'Firmware',
-                fr: 'Firmware version',
-                it: 'Versione firmware',
-                es: 'Versión de firmware',
-                pl: 'Okładka',
-                uk: 'Версія прошивки',
-                'zh-cn': '导 言',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('chip'),
-        },
+    common: {
+      name: {
+        en: "Device online",
+        de: "Gerät online",
+        ru: "Устройство онлайн",
+        pt: "Dispositivo online",
+        nl: "Device online",
+        fr: "Appareil en ligne",
+        it: "Dispositivo online",
+        es: "Dispositivo en línea",
+        pl: "Device online",
+        uk: "Пристрої онлайн",
+        "zh-cn": "网上证人",
+      },
+      type: "boolean",
+      role: "indicator.reachable",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("wifi"),
     },
-    'hostname': {
-        coap: {
-            init_funct: self => self.getIP(),
-        },
-        mqtt: {
-            init_funct: self => self.getIP(),
-        },
-        common: {
-            name: {
-                en: 'Device IP address or hostname',
-                de: 'Geräte-IP-Adresse oder Hostname',
-                ru: 'IP-адрес устройства или имя хоста',
-                pt: 'Endereço IP do dispositivo ou nome de host',
-                nl: 'IP-adres of gastnaam',
-                fr: 'Adresse IP ou nom d\'hôte',
-                it: 'Indirizzo IP del dispositivo o nome host',
-                es: 'Dirección IP o nombre de host',
-                pl: 'Adres IP lub hostname',
-                uk: 'Пристрої IP адреси або ім\'я користувача',
-                'zh-cn': '設備 IP 地址或主機名',
-            },
-            type: 'string',
-            role: 'info.ip',
-            read: true,
-            write: false,
-        },
+  },
+  firmware: {
+    coap: {
+      http_publish: "/status",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).update.has_update : undefined,
     },
-    'id': {
-        coap: {
-            init_funct: self => self.getDeviceId(),
-        },
-        mqtt: {
-            init_funct: self => self.getDeviceId(),
-        },
-        common: {
-            name: {
-                en: 'Device ID',
-                de: 'Gerätekennung',
-                ru: 'ID устройства',
-                pt: 'ID do dispositivo',
-                nl: 'Device ID',
-                fr: 'ID',
-                it: 'ID dispositivo',
-                es: 'ID de dispositivo',
-                pl: 'ID',
-                uk: 'Ідентифікатор пристрою',
-                'zh-cn': '設備ID',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+    mqtt: {
+      http_publish: "/status",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).update.has_update : undefined,
     },
-    'class': {
-        coap: {
-            init_funct: self => self.getDeviceClass(),
-        },
-        mqtt: {
-            init_funct: self => self.getDeviceClass(),
-        },
-        common: {
-            name: {
-                en: 'Device class',
-                de: 'Geräteklasse',
-                ru: 'Класс устройства',
-                pt: 'Classe de dispositivo',
-                nl: 'Device klas',
-                fr: 'Classe d\' appareil',
-                it: 'Classe di dispositivo',
-                es: 'Clase de dispositivo',
-                pl: 'Klasa Device',
-                uk: 'Клас пристрою',
-                'zh-cn': '证人阶级',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+    common: {
+      name: {
+        en: "New firmware available",
+        de: "Neue Firmware verfügbar",
+        ru: "Новая прошивка доступна",
+        pt: "Novo firmware disponível",
+        nl: "Nieuwe firmaware",
+        fr: "Nouveau firmware disponible",
+        it: "Nuovo firmware disponibile",
+        es: "Nuevo firmware disponible",
+        pl: "Nowy sprzęt",
+        uk: "Нова прошивка доступна",
+        "zh-cn": "新的警觉",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
     },
-    'type': {
-        coap: {
-            init_funct: self => self.getDeviceType(),
-        },
-        mqtt: {
-            init_funct: self => self.getDeviceType(),
-        },
-        common: {
-            name: {
-                en: 'Device type',
-                de: 'Gerätetyp',
-                ru: 'Тип устройства',
-                pt: 'Tipo de dispositivo',
-                nl: 'Device type',
-                fr: 'Type de dispositif',
-                it: 'Tipo di dispositivo',
-                es: 'Tipo de dispositivo',
-                pl: 'Device type',
-                uk: 'Тип пристрою',
-                'zh-cn': '設備類型',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+  },
+  firmwareupdate: {
+    coap: {
+      http_cmd: "/ota?update=true",
     },
-    'knowledgeBaseUrl': {
-        coap: {
-            init_funct: self => self.getKnowledgeBaseUrl(),
-        },
-        mqtt: {
-            init_funct: self => self.getKnowledgeBaseUrl(),
-        },
-        common: {
-            name: {
-                en: 'Knowledge base',
-                de: 'Wissensdatenbank',
-                ru: 'База знаний',
-                pt: 'Base de conhecimento',
-                nl: 'Kennisbasis',
-                fr: 'Base de connaissances',
-                it: 'Base di conoscenza',
-                es: 'Base de conocimientos',
-                pl: 'Baza wiedzy',
-                uk: 'База знань',
-                'zh-cn': '知识基础',
-            },
-            type: 'string',
-            role: 'url.blank',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('question'),
-        },
+    mqtt: {
+      http_cmd: "/ota?update=true",
     },
-    'authEnabled': {
-        coap: {
-            http_publish: '/settings',
-            http_publish_funct: (value, self) => {
-                const authEnabled = value ? JSON.parse(value)?.login?.enabled : undefined;
+    common: {
+      name: {
+        en: "Update firmware version",
+        de: "Firmware-Version aktualisieren",
+        ru: "Обновление версии прошивки",
+        pt: "Atualizar versão de firmware",
+        nl: "Update firmaware",
+        fr: "Update firmware version",
+        it: "Versione firmware di aggiornamento",
+        es: "Actualizar la versión de firmware",
+        pl: "Oficjalna strona",
+        uk: "Оновлення версії прошивки",
+        "zh-cn": "最新软件版本",
+      },
+      type: "boolean",
+      role: "button",
+      read: false,
+      write: true,
+      icon: shellyHelper.getIcon("update"),
+    },
+  },
+  uptime: {
+    coap: {
+      http_publish: "/status",
+      http_publish_funct: (value) =>
+        value ? parseInt(JSON.parse(value).uptime) : undefined,
+    },
+    mqtt: {
+      http_publish: "/status",
+      http_publish_funct: (value) =>
+        value ? parseInt(JSON.parse(value).uptime) : undefined,
+    },
+    common: {
+      name: {
+        en: "Device running since",
+        de: "Gerät läuft seit",
+        ru: "Устройство работает с",
+        pt: "Dispositivo em execução desde",
+        nl: "Device vlucht sinds",
+        fr: "Appareils fonctionnant depuis",
+        it: "Dispositivo in esecuzione da",
+        es: "Dispositivo funcionando desde",
+        pl: "Device biegnie od czasu do czasu",
+        uk: "Пристрої, що працюють з",
+        "zh-cn": "自那时以来丧失能力",
+      },
+      type: "number",
+      role: "value.interval",
+      unit: "sec",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("clock"),
+    },
+  },
+  version: {
+    coap: {
+      http_publish: "/settings",
+      http_publish_funct: (value) => (value ? JSON.parse(value).fw : undefined),
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: (value) => (value ? JSON.parse(value).fw : undefined),
+    },
+    common: {
+      name: {
+        en: "Firmware version",
+        de: "Firmware-Version",
+        ru: "Версия прошивки",
+        pt: "Versão de firmware",
+        nl: "Firmware",
+        fr: "Firmware version",
+        it: "Versione firmware",
+        es: "Versión de firmware",
+        pl: "Okładka",
+        uk: "Версія прошивки",
+        "zh-cn": "导 言",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("chip"),
+    },
+  },
+  hostname: {
+    coap: {
+      init_funct: (self) => self.getIP(),
+    },
+    mqtt: {
+      init_funct: (self) => self.getIP(),
+    },
+    common: {
+      name: {
+        en: "Device IP address or hostname",
+        de: "Geräte-IP-Adresse oder Hostname",
+        ru: "IP-адрес устройства или имя хоста",
+        pt: "Endereço IP do dispositivo ou nome de host",
+        nl: "IP-adres of gastnaam",
+        fr: "Adresse IP ou nom d'hôte",
+        it: "Indirizzo IP del dispositivo o nome host",
+        es: "Dirección IP o nombre de host",
+        pl: "Adres IP lub hostname",
+        uk: "Пристрої IP адреси або ім'я користувача",
+        "zh-cn": "設備 IP 地址或主機名",
+      },
+      type: "string",
+      role: "info.ip",
+      read: true,
+      write: false,
+    },
+  },
+  id: {
+    coap: {
+      init_funct: (self) => self.getDeviceId(),
+    },
+    mqtt: {
+      init_funct: (self) => self.getDeviceId(),
+    },
+    common: {
+      name: {
+        en: "Device ID",
+        de: "Gerätekennung",
+        ru: "ID устройства",
+        pt: "ID do dispositivo",
+        nl: "Device ID",
+        fr: "ID",
+        it: "ID dispositivo",
+        es: "ID de dispositivo",
+        pl: "ID",
+        uk: "Ідентифікатор пристрою",
+        "zh-cn": "設備ID",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  class: {
+    coap: {
+      init_funct: (self) => self.getDeviceClass(),
+    },
+    mqtt: {
+      init_funct: (self) => self.getDeviceClass(),
+    },
+    common: {
+      name: {
+        en: "Device class",
+        de: "Geräteklasse",
+        ru: "Класс устройства",
+        pt: "Classe de dispositivo",
+        nl: "Device klas",
+        fr: "Classe d' appareil",
+        it: "Classe di dispositivo",
+        es: "Clase de dispositivo",
+        pl: "Klasa Device",
+        uk: "Клас пристрою",
+        "zh-cn": "证人阶级",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  type: {
+    coap: {
+      init_funct: (self) => self.getDeviceType(),
+    },
+    mqtt: {
+      init_funct: (self) => self.getDeviceType(),
+    },
+    common: {
+      name: {
+        en: "Device type",
+        de: "Gerätetyp",
+        ru: "Тип устройства",
+        pt: "Tipo de dispositivo",
+        nl: "Device type",
+        fr: "Type de dispositif",
+        it: "Tipo di dispositivo",
+        es: "Tipo de dispositivo",
+        pl: "Device type",
+        uk: "Тип пристрою",
+        "zh-cn": "設備類型",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  knowledgeBaseUrl: {
+    coap: {
+      init_funct: (self) => self.getKnowledgeBaseUrl(),
+    },
+    mqtt: {
+      init_funct: (self) => self.getKnowledgeBaseUrl(),
+    },
+    common: {
+      name: {
+        en: "Knowledge base",
+        de: "Wissensdatenbank",
+        ru: "База знаний",
+        pt: "Base de conhecimento",
+        nl: "Kennisbasis",
+        fr: "Base de connaissances",
+        it: "Base di conoscenza",
+        es: "Base de conocimientos",
+        pl: "Baza wiedzy",
+        uk: "База знань",
+        "zh-cn": "知识基础",
+      },
+      type: "string",
+      role: "url.blank",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("question"),
+    },
+  },
+  authEnabled: {
+    coap: {
+      http_publish: "/settings",
+      http_publish_funct: (value, self) => {
+        const authEnabled = value
+          ? JSON.parse(value)?.login?.enabled
+          : undefined;
 
-                if (!authEnabled && self.adapter.config.httppassword) {
-                    self.adapter.log.warn(`[authEnabled] ${self.getLogInfo()}: This device is not protected via restricted login (see adapter documentation for details)`);
-                }
+        if (!authEnabled && self.adapter.config.httppassword) {
+          self.adapter.log.warn(
+            `[authEnabled] ${self.getLogInfo()}: This device is not protected via restricted login (see adapter documentation for details)`
+          );
+        }
 
-                return authEnabled;
-            },
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: (value, self) => {
-                const authEnabled = value ? JSON.parse(value)?.login?.enabled : undefined;
+        return authEnabled;
+      },
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: (value, self) => {
+        const authEnabled = value
+          ? JSON.parse(value)?.login?.enabled
+          : undefined;
 
-                if (!authEnabled && self.adapter.config.httppassword) {
-                    self.adapter.log.warn(`[authEnabled] ${self.getLogInfo()}: This device is not protected via restricted login (see adapter documentation for details)`);
-                }
+        if (!authEnabled && self.adapter.config.httppassword) {
+          self.adapter.log.warn(
+            `[authEnabled] ${self.getLogInfo()}: This device is not protected via restricted login (see adapter documentation for details)`
+          );
+        }
 
-                return authEnabled;
-            },
-        },
-        common: {
-            name: {
-                en: 'Authentication enabled',
-                de: 'Authentication aktiviert',
-                ru: 'Аутентификация включена',
-                pt: 'Autenticação activada',
-                nl: 'Authenticatie in staat',
-                fr: 'Authentification activée',
-                it: 'Autenticazione abilitata',
-                es: 'Autenticación habilitada',
-                pl: 'Authenticacja umożliwiła',
-                uk: 'Увімкнення аутентифікації',
-                'zh-cn': '逮捕使',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('auth'),
-        },
+        return authEnabled;
+      },
     },
-    'rssi': {
-        coap: {
-            http_publish: '/status',
-            http_publish_funct: value => value ? JSON.parse(value)?.wifi_sta?.rssi : 0,
-        },
-        mqtt: {
-            http_publish: '/status',
-            http_publish_funct: value => value ? JSON.parse(value)?.wifi_sta?.rssi : 0,
-        },
-        common: {
-            name: {
-                en: 'Received Signal Strength Indication',
-                de: 'Empfangene Signalstärkeanzeige',
-                ru: 'Получена индикация силы сигнала',
-                pt: 'Indicação de Força de Sinal Recebida',
-                nl: 'Vervangde Signal Strength Indicatie',
-                fr: 'Indication de force de signal reçue',
-                it: 'Indicazione di forza segnale ricevuta',
-                es: 'Indicación de fuerza de la señal recibida',
-                pl: 'Received Signal Strength (ang.)',
-                uk: 'Отриманий показ сигналу',
-                'zh-cn': '接受签字国制',
-            },
-            type: 'number',
-            role: 'value',
-            unit: 'dBm',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('signal'),
-        },
+    common: {
+      name: {
+        en: "Authentication enabled",
+        de: "Authentication aktiviert",
+        ru: "Аутентификация включена",
+        pt: "Autenticação activada",
+        nl: "Authenticatie in staat",
+        fr: "Authentification activée",
+        it: "Autenticazione abilitata",
+        es: "Autenticación habilitada",
+        pl: "Authenticacja umożliwiła",
+        uk: "Увімкнення аутентифікації",
+        "zh-cn": "逮捕使",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("auth"),
     },
-    'reboot': {
-        coap: {
-            http_cmd: '/reboot',
-        },
-        mqtt: {
-            http_cmd: '/reboot',
-        },
-        common: {
-            name: {
-                en: 'Reboot',
-                de: 'Neustart',
-                ru: 'Перезагрузка',
-                pt: 'Reiniciar',
-                nl: 'Reboot',
-                fr: 'Reboot',
-                it: 'Reboot',
-                es: 'Reboot',
-                pl: 'Reboot',
-                uk: 'Перезавантаження',
-                'zh-cn': 'Reboot',
-            },
-            type: 'boolean',
-            role: 'button',
-            read: false,
-            write: true,
-        },
+  },
+  rssi: {
+    coap: {
+      http_publish: "/status",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value)?.wifi_sta?.rssi : 0,
     },
-    'protocol': {
-        coap: {
-            init_value: 'coap',
-        },
-        mqtt: {
-            init_value: 'mqtt',
-        },
-        common: {
-            name: {
-                en: 'Protocol',
-                de: 'Protokoll',
-                ru: 'Протокол',
-                pt: 'Protocolo',
-                nl: 'Protocol',
-                fr: 'Protocole',
-                it: 'Protocollo',
-                es: 'Protocolo',
-                pl: 'Protokół',
-                uk: 'Протокол',
-                'zh-cn': '议定书',
-            },
-            type: 'string',
-            role: 'text',
-            read: true,
-            write: false,
-        },
+    mqtt: {
+      http_publish: "/status",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value)?.wifi_sta?.rssi : 0,
     },
-    'name': {
-        coap: {
-            http_publish: '/settings',
-            http_publish_funct: async (value, self) => value ? await shellyHelper.setDeviceName(self, JSON.parse(value).name) : undefined,
-            http_cmd: '/settings',
-            http_cmd_funct: value => ({ name: value }),
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: async (value, self) => value ? await shellyHelper.setDeviceName(self, JSON.parse(value).name) : undefined,
-            http_cmd: '/settings',
-            http_cmd_funct: value => ({ name: value }),
-        },
-        common: {
-            name: {
-                en: 'Device name',
-                de: 'Bezeichnung des Geräts',
-                ru: 'Наименование устройства',
-                pt: 'Nome do dispositivo',
-                nl: 'Devicenaam',
-                fr: 'Nom du dispositif',
-                it: 'Nome del dispositivo',
-                es: 'Nombre del dispositivo',
-                pl: 'Device name',
-                uk: 'Назва пристрою',
-                'zh-cn': '证人姓名',
-            },
-            type: 'string',
-            role: 'info.name',
-            read: true,
-            write: true,
-            icon: shellyHelper.getIcon('signature'),
-        },
+    common: {
+      name: {
+        en: "Received Signal Strength Indication",
+        de: "Empfangene Signalstärkeanzeige",
+        ru: "Получена индикация силы сигнала",
+        pt: "Indicação de Força de Sinal Recebida",
+        nl: "Vervangde Signal Strength Indicatie",
+        fr: "Indication de force de signal reçue",
+        it: "Indicazione di forza segnale ricevuta",
+        es: "Indicación de fuerza de la señal recibida",
+        pl: "Received Signal Strength (ang.)",
+        uk: "Отриманий показ сигналу",
+        "zh-cn": "接受签字国制",
+      },
+      type: "number",
+      role: "value",
+      unit: "dBm",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("signal"),
     },
-    'Sys.eco': {
-        coap: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).eco_mode_enabled : undefined,
-            http_cmd: '/settings',
-            http_cmd_funct: value => ({ eco_mode_enabled: value }),
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).eco_mode_enabled : undefined,
-            http_cmd: '/settings',
-            http_cmd_funct: value => ({ eco_mode_enabled: value }),
-        },
-        common: {
-            name: {
-                en: 'Eco Mode',
-                de: 'Eco-Modus',
-                ru: 'Эко режим',
-                pt: 'Modo Eco',
-                nl: 'Eco Mode',
-                fr: 'Eco Mode',
-                it: 'Modalità Eco',
-                es: 'Eco Mode',
-                pl: 'Eko',
-                uk: 'Еко режим',
-                'zh-cn': 'Eco Mode',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: true,
-        },
+  },
+  reboot: {
+    coap: {
+      http_cmd: "/reboot",
     },
-    'Sys.sntp': {
-        coap: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).sntp.server : undefined,
-            http_cmd: '/settings',
-            http_cmd_funct: value => ({ sntp_server: value }),
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).sntp.server : undefined,
-            http_cmd: '/settings',
-            http_cmd_funct: value => ({ sntp_server: value }),
-        },
-        common: {
-            name: {
-                en: 'SNTP Server',
-                de: 'SNTP Server',
-                ru: 'SNTP сервер',
-                pt: 'Servidor SNTP',
-                nl: 'SNTP',
-                fr: 'SNTP Server',
-                it: 'Server SNTP',
-                es: 'SNTP Server',
-                pl: 'SNTP Server',
-                uk: 'Статус на сервери',
-                'zh-cn': 'SNTP Server',
-            },
-            type: 'string',
-            role: 'text.url',
-            read: true,
-            write: true,
-        },
+    mqtt: {
+      http_cmd: "/reboot",
     },
-    'Sys.timezone': {
-        coap: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).timezone : undefined,
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).timezone : undefined,
-        },
-        common: {
-            name: {
-                en: 'Timezone',
-                de: 'Zeitzone',
-                ru: 'Часовой пояс',
-                pt: 'Fuso horário',
-                nl: 'Tijdzone',
-                fr: 'Timezone',
-                it: 'Tempo',
-                es: 'Zona horaria',
-                pl: 'Timezone',
-                uk: 'Часовий пояс',
-                'zh-cn': '时间区',
-            },
-            type: 'string',
-            role: 'text',
-            read: true,
-            write: false,
-        },
+    common: {
+      name: {
+        en: "Reboot",
+        de: "Neustart",
+        ru: "Перезагрузка",
+        pt: "Reiniciar",
+        nl: "Reboot",
+        fr: "Reboot",
+        it: "Reboot",
+        es: "Reboot",
+        pl: "Reboot",
+        uk: "Перезавантаження",
+        "zh-cn": "Reboot",
+      },
+      type: "boolean",
+      role: "button",
+      read: false,
+      write: true,
     },
-    'Sys.lat': {
-        coap: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).lat : undefined,
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).lat : undefined,
-        },
-        common: {
-            name: {
-                en: 'Latitude',
-                de: 'Breite',
-                ru: 'Широта',
-                pt: 'Latitude',
-                nl: 'Latitude',
-                fr: 'Latitude',
-                it: 'Latitudine',
-                es: 'Latitud',
-                pl: 'Latitudes',
-                uk: 'Прованс',
-                'zh-cn': '学历',
-            },
-            type: 'number',
-            role: 'value.gps.latitude',
-            read: true,
-            write: false,
-        },
+  },
+  protocol: {
+    coap: {
+      init_value: "coap",
     },
-    'Sys.lon': {
-        coap: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).lng : undefined,
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: value => value ? JSON.parse(value).lng : undefined,
-        },
-        common: {
-            name: {
-                en: 'Longitude',
-                de: 'Länge',
-                ru: 'Долгота',
-                pt: 'Longitude',
-                nl: 'Longit',
-                fr: 'Longitude',
-                it: 'Longitudine',
-                es: 'Longitud',
-                pl: 'Długość',
-                uk: 'Довгий',
-                'zh-cn': '长 度',
-            },
-            type: 'number',
-            role: 'value.gps.longitude',
-            read: true,
-            write: false,
-        },
+    mqtt: {
+      init_value: "mqtt",
     },
-    'Mqtt.topicPrefix': {
-        coap: {
-            no_display: true,
-        },
-        mqtt: {
-            http_publish: '/settings',
-            http_publish_funct: (value, self) => {
-                const result = value ? JSON.parse(value)?.mqtt?.id : undefined;
-                if (result && self.getMqttPrefix() && result !== self.getMqttPrefix()) {
-                    self.adapter.log.warn(`[Mqtt.topicPrefix] ${self.getLogInfo()}: Configured mqtt topic prefix "${result}" and actual topic prefix "${self.getMqttPrefix()}" do not match. Please check configuration`);
-                }
+    common: {
+      name: {
+        en: "Protocol",
+        de: "Protokoll",
+        ru: "Протокол",
+        pt: "Protocolo",
+        nl: "Protocol",
+        fr: "Protocole",
+        it: "Protocollo",
+        es: "Protocolo",
+        pl: "Protokół",
+        uk: "Протокол",
+        "zh-cn": "议定书",
+      },
+      type: "string",
+      role: "text",
+      read: true,
+      write: false,
+    },
+  },
+  name: {
+    coap: {
+      http_publish: "/settings",
+      http_publish_funct: async (value, self) =>
+        value
+          ? await shellyHelper.setDeviceName(self, JSON.parse(value).name)
+          : undefined,
+      http_cmd: "/settings",
+      http_cmd_funct: (value) => ({ name: value }),
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: async (value, self) =>
+        value
+          ? await shellyHelper.setDeviceName(self, JSON.parse(value).name)
+          : undefined,
+      http_cmd: "/settings",
+      http_cmd_funct: (value) => ({ name: value }),
+    },
+    common: {
+      name: {
+        en: "Device name",
+        de: "Bezeichnung des Geräts",
+        ru: "Наименование устройства",
+        pt: "Nome do dispositivo",
+        nl: "Devicenaam",
+        fr: "Nom du dispositif",
+        it: "Nome del dispositivo",
+        es: "Nombre del dispositivo",
+        pl: "Device name",
+        uk: "Назва пристрою",
+        "zh-cn": "证人姓名",
+      },
+      type: "string",
+      role: "info.name",
+      read: true,
+      write: true,
+      icon: shellyHelper.getIcon("signature"),
+    },
+  },
+  "Sys.eco": {
+    coap: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).eco_mode_enabled : undefined,
+      http_cmd: "/settings",
+      http_cmd_funct: (value) => ({ eco_mode_enabled: value }),
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).eco_mode_enabled : undefined,
+      http_cmd: "/settings",
+      http_cmd_funct: (value) => ({ eco_mode_enabled: value }),
+    },
+    common: {
+      name: {
+        en: "Eco Mode",
+        de: "Eco-Modus",
+        ru: "Эко режим",
+        pt: "Modo Eco",
+        nl: "Eco Mode",
+        fr: "Eco Mode",
+        it: "Modalità Eco",
+        es: "Eco Mode",
+        pl: "Eko",
+        uk: "Еко режим",
+        "zh-cn": "Eco Mode",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.sntp": {
+    coap: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).sntp.server : undefined,
+      http_cmd: "/settings",
+      http_cmd_funct: (value) => ({ sntp_server: value }),
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).sntp.server : undefined,
+      http_cmd: "/settings",
+      http_cmd_funct: (value) => ({ sntp_server: value }),
+    },
+    common: {
+      name: {
+        en: "SNTP Server",
+        de: "SNTP Server",
+        ru: "SNTP сервер",
+        pt: "Servidor SNTP",
+        nl: "SNTP",
+        fr: "SNTP Server",
+        it: "Server SNTP",
+        es: "SNTP Server",
+        pl: "SNTP Server",
+        uk: "Статус на сервери",
+        "zh-cn": "SNTP Server",
+      },
+      type: "string",
+      role: "text.url",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.timezone": {
+    coap: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).timezone : undefined,
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).timezone : undefined,
+    },
+    common: {
+      name: {
+        en: "Timezone",
+        de: "Zeitzone",
+        ru: "Часовой пояс",
+        pt: "Fuso horário",
+        nl: "Tijdzone",
+        fr: "Timezone",
+        it: "Tempo",
+        es: "Zona horaria",
+        pl: "Timezone",
+        uk: "Часовий пояс",
+        "zh-cn": "时间区",
+      },
+      type: "string",
+      role: "text",
+      read: true,
+      write: false,
+    },
+  },
+  "Sys.lat": {
+    coap: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).lat : undefined,
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).lat : undefined,
+    },
+    common: {
+      name: {
+        en: "Latitude",
+        de: "Breite",
+        ru: "Широта",
+        pt: "Latitude",
+        nl: "Latitude",
+        fr: "Latitude",
+        it: "Latitudine",
+        es: "Latitud",
+        pl: "Latitudes",
+        uk: "Прованс",
+        "zh-cn": "学历",
+      },
+      type: "number",
+      role: "value.gps.latitude",
+      read: true,
+      write: false,
+    },
+  },
+  "Sys.lon": {
+    coap: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).lng : undefined,
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).lng : undefined,
+    },
+    common: {
+      name: {
+        en: "Longitude",
+        de: "Länge",
+        ru: "Долгота",
+        pt: "Longitude",
+        nl: "Longit",
+        fr: "Longitude",
+        it: "Longitudine",
+        es: "Longitud",
+        pl: "Długość",
+        uk: "Довгий",
+        "zh-cn": "长 度",
+      },
+      type: "number",
+      role: "value.gps.longitude",
+      read: true,
+      write: false,
+    },
+  },
+  "Mqtt.topicPrefix": {
+    coap: {
+      no_display: true,
+    },
+    mqtt: {
+      http_publish: "/settings",
+      http_publish_funct: (value, self) => {
+        const result = value ? JSON.parse(value)?.mqtt?.id : undefined;
+        if (result && self.getMqttPrefix() && result !== self.getMqttPrefix()) {
+          self.adapter.log.warn(
+            `[Mqtt.topicPrefix] ${self.getLogInfo()}: Configured mqtt topic prefix "${result}" and actual topic prefix "${self.getMqttPrefix()}" do not match. Please check configuration`
+          );
+        }
 
-                return result;
-            },
-        },
-        common: {
-            name: {
-                en: 'Topic prefix',
-                de: 'Thema Präfix',
-                ru: 'Тема префикса',
-                pt: 'Prefixo de tópico',
-                nl: 'Onderwerp voorvoegsel',
-                fr: 'Préfixe du sujet',
-                it: 'Prefisso tematico',
-                es: 'Prefijo temático',
-                pl: 'Przedrostek',
-                uk: 'Тема префікса',
-                'zh-cn': '主题前',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+        return result;
+      },
     },
-    'Mqtt.clientId': {
-        coap: {
-            no_display: true,
-        },
-        mqtt: {
-            init_funct: self => self.getId(),
-            http_publish: '/settings',
-            http_publish_funct: (value, self) => self.getId(),
-        },
-        common: {
-            name: {
-                en: 'Client ID',
-                de: 'Client-ID',
-                ru: 'ID клиента',
-                pt: 'ID do cliente',
-                nl: 'Cliënt ID',
-                fr: 'ID client',
-                it: 'ID cliente',
-                es: 'ID de cliente',
-                pl: 'Klient Ident',
-                uk: 'Клієнт',
-                'zh-cn': '客户',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+    common: {
+      name: {
+        en: "Topic prefix",
+        de: "Thema Präfix",
+        ru: "Тема префикса",
+        pt: "Prefixo de tópico",
+        nl: "Onderwerp voorvoegsel",
+        fr: "Préfixe du sujet",
+        it: "Prefisso tematico",
+        es: "Prefijo temático",
+        pl: "Przedrostek",
+        uk: "Тема префікса",
+        "zh-cn": "主题前",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
     },
-    'Cloud.enabled': {
-        coap: {
-            http_publish: '/status',
-            http_publish_funct: value => value ? JSON.parse(value)?.cloud?.enabled : undefined,
-        },
-        mqtt: {
-            http_publish: '/status',
-            http_publish_funct: value => value ? JSON.parse(value)?.cloud?.enabled : undefined,
-        },
-        common: {
-            name: {
-                en: 'Cloud Connection',
-                de: 'Cloud-Verbindung',
-                ru: 'Облачное соединение',
-                pt: 'Conexão de nuvem',
-                nl: 'Cloud Connection',
-                fr: 'Cloud Connection',
-                it: 'Connessione cloud',
-                es: 'Cloud Connection',
-                pl: 'Cloud Connection',
-                uk: 'Хмарне підключення',
-                'zh-cn': 'Cloud Connection',
-            },
-            type: 'boolean',
-            role: 'switch.enable',
-            read: true,
-            write: false,
-        },
+  },
+  "Mqtt.clientId": {
+    coap: {
+      no_display: true,
     },
+    mqtt: {
+      init_funct: (self) => self.getId(),
+      http_publish: "/settings",
+      http_publish_funct: (value, self) => self.getId(),
+    },
+    common: {
+      name: {
+        en: "Client ID",
+        de: "Client-ID",
+        ru: "ID клиента",
+        pt: "ID do cliente",
+        nl: "Cliënt ID",
+        fr: "ID client",
+        it: "ID cliente",
+        es: "ID de cliente",
+        pl: "Klient Ident",
+        uk: "Клієнт",
+        "zh-cn": "客户",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  "Cloud.enabled": {
+    coap: {
+      http_publish: "/status",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value)?.cloud?.enabled : undefined,
+    },
+    mqtt: {
+      http_publish: "/status",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value)?.cloud?.enabled : undefined,
+    },
+    common: {
+      name: {
+        en: "Cloud Connection",
+        de: "Cloud-Verbindung",
+        ru: "Облачное соединение",
+        pt: "Conexão de nuvem",
+        nl: "Cloud Connection",
+        fr: "Cloud Connection",
+        it: "Connessione cloud",
+        es: "Cloud Connection",
+        pl: "Cloud Connection",
+        uk: "Хмарне підключення",
+        "zh-cn": "Cloud Connection",
+      },
+      type: "boolean",
+      role: "switch.enable",
+      read: true,
+      write: false,
+    },
+  },
 };
 
 /**
@@ -738,64 +773,65 @@ const defaultsgen1 = {
  * https://shelly-api-docs.shelly.cloud/gen2/
  */
 const defaultsgen2 = {
-    'gen': {
-        mqtt: {
-            init_funct: self => self.getDeviceGen(),
-        },
-        common: {
-            name: {
-                en: 'Device generation',
-                de: 'Gerätegeneration',
-                ru: 'Генерация устройства',
-                pt: 'Geração de dispositivos',
-                nl: 'Vernietigingsgeneratie',
-                fr: 'Production d\'appareils',
-                it: 'Generazione di dispositivi',
-                es: 'Generación de dispositivos',
-                pl: 'Pokolenie Device',
-                uk: 'Виробництво',
-                'zh-cn': '代 人',
-            },
-            type: 'number',
-            role: 'state',
-            read: true,
-            write: false,
-            states: {
-                1: 'Generation 1',
-                2: 'Generation 2',
-            },
-        },
+  gen: {
+    mqtt: {
+      init_funct: (self) => self.getDeviceGen(),
     },
-    'online': {
-        mqtt: {
-            init_funct: self => self.isOnline(),
-        },
-        common: {
-            name: {
-                en: 'Device online',
-                de: 'Gerät online',
-                ru: 'Устройство онлайн',
-                pt: 'Dispositivo online',
-                nl: 'Device online',
-                fr: 'Appareil en ligne',
-                it: 'Dispositivo online',
-                es: 'Dispositivo en línea',
-                pl: 'Device online',
-                uk: 'Пристрої онлайн',
-                'zh-cn': '网上证人',
-            },
-            type: 'boolean',
-            role: 'indicator.reachable',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('wifi'),
-        },
+    common: {
+      name: {
+        en: "Device generation",
+        de: "Gerätegeneration",
+        ru: "Генерация устройства",
+        pt: "Geração de dispositivos",
+        nl: "Vernietigingsgeneratie",
+        fr: "Production d'appareils",
+        it: "Generazione di dispositivi",
+        es: "Generación de dispositivos",
+        pl: "Pokolenie Device",
+        uk: "Виробництво",
+        "zh-cn": "代 人",
+      },
+      type: "number",
+      role: "state",
+      read: true,
+      write: false,
+      states: {
+        1: "Generation 1",
+        2: "Generation 2",
+        3: "Generation 3",
+      },
     },
-    'firmware': {
-        mqtt: {
-            http_publish: '/rpc/Shelly.GetStatus',
-            http_publish_funct: value => {
-                /*
+  },
+  online: {
+    mqtt: {
+      init_funct: (self) => self.isOnline(),
+    },
+    common: {
+      name: {
+        en: "Device online",
+        de: "Gerät online",
+        ru: "Устройство онлайн",
+        pt: "Dispositivo online",
+        nl: "Device online",
+        fr: "Appareil en ligne",
+        it: "Dispositivo online",
+        es: "Dispositivo en línea",
+        pl: "Device online",
+        uk: "Пристрої онлайн",
+        "zh-cn": "网上证人",
+      },
+      type: "boolean",
+      role: "indicator.reachable",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("wifi"),
+    },
+  },
+  firmware: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetStatus",
+      http_publish_funct: (value) => {
+        /*
                 "sys": {
                     ...
                     "available_updates": {
@@ -805,762 +841,1791 @@ const defaultsgen2 = {
                     }
                 }
                 */
-                if (value) {
-                    const valueObj = JSON.parse(value);
-                    if (valueObj?.sys?.available_updates?.stable?.version) {
-                        return true;
+        if (value) {
+          const valueObj = JSON.parse(value);
+          if (valueObj?.sys?.available_updates?.stable?.version) {
+            return true;
+          }
+        }
+
+        return false;
+      },
+    },
+    common: {
+      name: {
+        en: "New firmware available",
+        de: "Neue Firmware verfügbar",
+        ru: "Новая прошивка доступна",
+        pt: "Novo firmware disponível",
+        nl: "Nieuwe firmaware",
+        fr: "Nouveau firmware disponible",
+        it: "Nuovo firmware disponibile",
+        es: "Nuevo firmware disponible",
+        pl: "Nowy sprzęt",
+        uk: "Нова прошивка доступна",
+        "zh-cn": "新的警觉",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  firmwareupdate: {
+    mqtt: {
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Shelly.Update",
+          params: { stage: "stable" },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Update firmware version",
+        de: "Firmware-Version aktualisieren",
+        ru: "Обновление версии прошивки",
+        pt: "Atualizar versão de firmware",
+        nl: "Update firmaware",
+        fr: "Update firmware version",
+        it: "Versione firmware di aggiornamento",
+        es: "Actualizar la versión de firmware",
+        pl: "Oficjalna strona",
+        uk: "Оновлення версії прошивки",
+        "zh-cn": "最新软件版本",
+      },
+      type: "boolean",
+      role: "button",
+      read: false,
+      write: true,
+      icon: shellyHelper.getIcon("update"),
+    },
+  },
+  uptime: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetStatus",
+      http_publish_funct: (value) =>
+        value ? parseInt(JSON.parse(value).sys.uptime) : undefined,
+    },
+    common: {
+      name: {
+        en: "Device running since",
+        de: "Gerät läuft seit",
+        ru: "Устройство работает с",
+        pt: "Dispositivo em execução desde",
+        nl: "Device vlucht sinds",
+        fr: "Appareils fonctionnant depuis",
+        it: "Dispositivo in esecuzione da",
+        es: "Dispositivo funcionando desde",
+        pl: "Device biegnie od czasu do czasu",
+        uk: "Пристрої, що працюють з",
+        "zh-cn": "自那时以来丧失能力",
+      },
+      type: "number",
+      role: "value.interval",
+      unit: "sec",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("clock"),
+    },
+  },
+  version: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetDeviceInfo",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).fw_id : undefined,
+    },
+    common: {
+      name: {
+        en: "Firmware version",
+        de: "Firmware-Version",
+        ru: "Версия прошивки",
+        pt: "Versão de firmware",
+        nl: "Firmware",
+        fr: "Firmware version",
+        it: "Versione firmware",
+        es: "Versión de firmware",
+        pl: "Okładka",
+        uk: "Версія прошивки",
+        "zh-cn": "导 言",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("chip"),
+    },
+  },
+  hostname: {
+    mqtt: {
+      init_funct: (self) => self.getIP(),
+    },
+    common: {
+      name: {
+        en: "Device IP address or hostname",
+        de: "Geräte-IP-Adresse oder Hostname",
+        ru: "IP-адрес устройства или имя хоста",
+        pt: "Endereço IP do dispositivo ou nome de host",
+        nl: "IP-adres of gastnaam",
+        fr: "Adresse IP ou nom d'hôte",
+        it: "Indirizzo IP del dispositivo o nome host",
+        es: "Dirección IP o nombre de host",
+        pl: "Adres IP lub hostname",
+        uk: "Пристрої IP адреси або ім'я користувача",
+        "zh-cn": "設備 IP 地址或主機名",
+      },
+      type: "string",
+      role: "info.ip",
+      read: true,
+      write: false,
+    },
+  },
+  id: {
+    mqtt: {
+      init_funct: (self) => self.getDeviceId(),
+    },
+    common: {
+      name: {
+        en: "Device ID",
+        de: "Gerätekennung",
+        ru: "ID устройства",
+        pt: "ID do dispositivo",
+        nl: "Device ID",
+        fr: "ID",
+        it: "ID dispositivo",
+        es: "ID de dispositivo",
+        pl: "ID",
+        uk: "Ідентифікатор пристрою",
+        "zh-cn": "設備ID",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  class: {
+    mqtt: {
+      init_funct: (self) => self.getDeviceClass(),
+    },
+    common: {
+      name: {
+        en: "Device class",
+        de: "Geräteklasse",
+        ru: "Класс устройства",
+        pt: "Classe de dispositivo",
+        nl: "Device klas",
+        fr: "Classe d' appareil",
+        it: "Classe di dispositivo",
+        es: "Clase de dispositivo",
+        pl: "Klasa Device",
+        uk: "Клас пристрою",
+        "zh-cn": "证人阶级",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  type: {
+    mqtt: {
+      init_funct: (self) => self.getDeviceType(),
+    },
+    common: {
+      name: {
+        en: "Device type",
+        de: "Gerätetyp",
+        ru: "Тип устройства",
+        pt: "Tipo de dispositivo",
+        nl: "Device type",
+        fr: "Type de dispositif",
+        it: "Tipo di dispositivo",
+        es: "Tipo de dispositivo",
+        pl: "Device type",
+        uk: "Тип пристрою",
+        "zh-cn": "設備類型",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  model: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetDeviceInfo",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).model : undefined,
+    },
+    common: {
+      name: {
+        en: "Device model",
+        de: "Gerätemodell",
+        ru: "Модель устройства",
+        pt: "Modelo de dispositivo",
+        nl: "Vernietig model",
+        fr: "Modèle de dispositif",
+        it: "Modello del dispositivo",
+        es: "Modelo de dispositivo",
+        pl: "Model",
+        uk: "Модель пристрою",
+        "zh-cn": "证人模式",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  knowledgeBaseUrl: {
+    mqtt: {
+      init_funct: (self) => self.getKnowledgeBaseUrl(),
+    },
+    common: {
+      name: {
+        en: "Knowledge base",
+        de: "Wissensdatenbank",
+        ru: "База знаний",
+        pt: "Base de conhecimento",
+        nl: "Kennisbasis",
+        fr: "Base de connaissances",
+        it: "Base di conoscenza",
+        es: "Base de conocimientos",
+        pl: "Baza wiedzy",
+        uk: "База знань",
+        "zh-cn": "知识基础",
+      },
+      type: "string",
+      role: "url.blank",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("question"),
+    },
+  },
+  authEnabled: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetDeviceInfo",
+      http_publish_funct: (value, self) => {
+        const authEnabled = value ? JSON.parse(value).auth_en : undefined;
+
+        if (!authEnabled && self.adapter.config.httppassword) {
+          self.adapter.log.warn(
+            `[authEnabled] ${self.getLogInfo()}: This device is not protected via restricted login (see adapter documentation for details)`
+          );
+        }
+
+        return authEnabled;
+      },
+    },
+    common: {
+      name: {
+        en: "Authentication enabled",
+        de: "Authentication aktiviert",
+        ru: "Аутентификация включена",
+        pt: "Autenticação activada",
+        nl: "Authenticatie in staat",
+        fr: "Authentification activée",
+        it: "Autenticazione abilitata",
+        es: "Autenticación habilitada",
+        pl: "Authenticacja umożliwiła",
+        uk: "Увімкнення аутентифікації",
+        "zh-cn": "逮捕使",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("auth"),
+    },
+  },
+  rssi: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetStatus",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).wifi.rssi : undefined,
+    },
+    common: {
+      name: {
+        en: "Received Signal Strength Indication",
+        de: "Empfangene Signalstärkeanzeige",
+        ru: "Получена индикация силы сигнала",
+        pt: "Indicação de Força de Sinal Recebida",
+        nl: "Vervangde Signal Strength Indicatie",
+        fr: "Indication de force de signal reçue",
+        it: "Indicazione di forza segnale ricevuta",
+        es: "Indicación de fuerza de la señal recibida",
+        pl: "Received Signal Strength (ang.)",
+        uk: "Отриманий показ сигналу",
+        "zh-cn": "接受签字国制",
+      },
+      type: "number",
+      role: "value",
+      unit: "dBm",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("signal"),
+    },
+  },
+  reboot: {
+    mqtt: {
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Shelly.Reboot",
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Reboot",
+        de: "Neustart",
+        ru: "Перезагрузка",
+        pt: "Reiniciar",
+        nl: "Reboot",
+        fr: "Reboot",
+        it: "Reboot",
+        es: "Reboot",
+        pl: "Reboot",
+        uk: "Перезавантаження",
+        "zh-cn": "Reboot",
+      },
+      type: "boolean",
+      role: "button",
+      read: false,
+      write: true,
+    },
+  },
+  protocol: {
+    mqtt: {
+      init_value: "mqtt",
+    },
+    common: {
+      name: {
+        en: "Protocol",
+        de: "Protokoll",
+        ru: "Протокол",
+        pt: "Protocolo",
+        nl: "Protocol",
+        fr: "Protocole",
+        it: "Protocollo",
+        es: "Protocolo",
+        pl: "Protokół",
+        uk: "Протокол",
+        "zh-cn": "议定书",
+      },
+      type: "string",
+      role: "text",
+      read: true,
+      write: false,
+    },
+  },
+  name: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetDeviceInfo",
+      http_publish_funct: async (value, self) =>
+        value
+          ? await shellyHelper.setDeviceName(self, JSON.parse(value).name)
+          : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { device: { name: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Device name",
+        de: "Bezeichnung des Geräts",
+        ru: "Наименование устройства",
+        pt: "Nome do dispositivo",
+        nl: "Devicenaam",
+        fr: "Nom du dispositif",
+        it: "Nome del dispositivo",
+        es: "Nombre del dispositivo",
+        pl: "Device name",
+        uk: "Назва пристрою",
+        "zh-cn": "证人姓名",
+      },
+      type: "string",
+      role: "info.name",
+      read: true,
+      write: true,
+      icon: shellyHelper.getIcon("signature"),
+    },
+  },
+  "Sys.eco": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).device.eco_mode : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { device: { eco_mode: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Eco Mode",
+        de: "Eco-Modus",
+        ru: "Эко режим",
+        pt: "Modo Eco",
+        nl: "Eco Mode",
+        fr: "Eco Mode",
+        it: "Modalità Eco",
+        es: "Eco Mode",
+        pl: "Eko",
+        uk: "Еко режим",
+        "zh-cn": "Eco Mode",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.sntp": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).sntp.server : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { sntp: { server: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "SNTP Server",
+        de: "SNTP Server",
+        ru: "SNTP сервер",
+        pt: "Servidor SNTP",
+        nl: "SNTP",
+        fr: "SNTP Server",
+        it: "Server SNTP",
+        es: "SNTP Server",
+        pl: "SNTP Server",
+        uk: "Статус на сервери",
+        "zh-cn": "SNTP Server",
+      },
+      type: "string",
+      role: "text.url",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.timezone": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).location.tz : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { location: { tz: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Timezone",
+        de: "Zeitzone",
+        ru: "Часовой пояс",
+        pt: "Fuso horário",
+        nl: "Tijdzone",
+        fr: "Timezone",
+        it: "Tempo",
+        es: "Zona horaria",
+        pl: "Timezone",
+        uk: "Часовий пояс",
+        "zh-cn": "时间区",
+      },
+      type: "string",
+      role: "text",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.lat": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).location.lat : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { location: { lat: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Latitude",
+        de: "Breite",
+        ru: "Широта",
+        pt: "Latitude",
+        nl: "Latitude",
+        fr: "Latitude",
+        it: "Latitudine",
+        es: "Latitud",
+        pl: "Latitudes",
+        uk: "Прованс",
+        "zh-cn": "学历",
+      },
+      type: "number",
+      role: "value.gps.latitude",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.lon": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).location.lon : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { location: { lon: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Longitude",
+        de: "Länge",
+        ru: "Долгота",
+        pt: "Longitude",
+        nl: "Longit",
+        fr: "Longitude",
+        it: "Longitudine",
+        es: "Longitud",
+        pl: "Długość",
+        uk: "Довгий",
+        "zh-cn": "长 度",
+      },
+      type: "number",
+      role: "value.gps.longitude",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.debugEnabled": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).debug.mqtt.enable : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { debug: { mqtt: { enable: value } } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Debug mode",
+        de: "Debug-Modus",
+        ru: "Режим Debug",
+        pt: "Modo de depuração",
+        nl: "Debug mode",
+        fr: "Mode Debug",
+        it: "Modalità Debug",
+        es: "Modo de depuración",
+        pl: "Tryb debugowania",
+        uk: "Режим Debug",
+        "zh-cn": "Dbug模式",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: true,
+    },
+  },
+  "WiFi.apEnabled": {
+    mqtt: {
+      http_publish: "/rpc/WiFi.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).ap.enable : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "WiFi.SetConfig",
+          params: { config: { ap: { enable: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Access point enabled",
+        de: "Access Point aktiviert",
+        ru: "Доступ к точке включен",
+        pt: "Ponto de acesso habilitado",
+        nl: "Toegangspunt in staat",
+        fr: "Point d ' accès activé",
+        it: "Punto di accesso abilitato",
+        es: "Punto de acceso habilitado",
+        pl: "Punkt dostępu umożliwiał",
+        uk: "Увімкнути точку доступу",
+        "zh-cn": "进入点",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: true,
+    },
+  },
+  "Mqtt.topicPrefix": {
+    mqtt: {
+      http_publish: "/rpc/Mqtt.GetConfig",
+      http_publish_funct: (value, self) => {
+        const result = value ? JSON.parse(value).topic_prefix : undefined;
+        if (result && self.getMqttPrefix() && result !== self.getMqttPrefix()) {
+          self.adapter.log.warn(
+            `[Mqtt.topicPrefix] ${self.getLogInfo()}: Configured mqtt topic prefix "${result}" and actual topic prefix "${self.getMqttPrefix()}" do not match. Please check configuration`
+          );
+        }
+
+        return result;
+      },
+    },
+    common: {
+      name: {
+        en: "Topic prefix",
+        de: "Thema Präfix",
+        ru: "Тема префикса",
+        pt: "Prefixo de tópico",
+        nl: "Onderwerp voorvoegsel",
+        fr: "Préfixe du sujet",
+        it: "Prefisso tematico",
+        es: "Prefijo temático",
+        pl: "Przedrostek",
+        uk: "Тема префікса",
+        "zh-cn": "主题前",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  "Mqtt.rpcNotifications": {
+    mqtt: {
+      http_publish: "/rpc/Mqtt.GetConfig",
+      http_publish_funct: (value, self) => {
+        const result = value ? JSON.parse(value).rpc_ntf : undefined;
+        if (result === false) {
+          self.adapter.log.warn(
+            `[Mqtt.rpcNotifications] ${self.getLogInfo()}: "RPC Status Notifications" are disabled (see adapter documentation for details)`
+          );
+        }
+
+        return result;
+      },
+    },
+    common: {
+      name: {
+        en: "RPC status notifications enabled",
+        de: "RPC-Statusmeldungen aktiviert",
+        ru: "Уведомления о состоянии RPC включены",
+        pt: "Notificações de status RPC habilitado",
+        nl: "RPC status melding",
+        fr: "Notifications de statut RPC activées",
+        it: "Notifiche di stato RPC abilitate",
+        es: "Se han habilitado notificaciones de la categoría RPC",
+        pl: "Statystyki RPC",
+        uk: "Повідомлення про статус РПК ввімкнено",
+        "zh-cn": "方案执行情况通知",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  "Mqtt.statusNotifications": {
+    mqtt: {
+      http_publish: "/rpc/Mqtt.GetConfig",
+      http_publish_funct: (value, self) => {
+        const result = value ? JSON.parse(value).status_ntf : undefined;
+        if (result === false) {
+          self.adapter.log.warn(
+            `[Mqtt.statusNotifications] ${self.getLogInfo()}: "General Status Notifications" are disabled (see adapter documentation for details)`
+          );
+        }
+
+        return result;
+      },
+    },
+    common: {
+      name: {
+        en: "Generic status notifications enabled",
+        de: "Generelle Statusmeldungen aktiviert",
+        ru: "Уведомления о генерическом статусе включены",
+        pt: "Notificações de status genéricas activadas",
+        nl: "Generische status melding",
+        fr: "Notifications d'état générique activé",
+        it: "Notifiche di stato generiche abilitate",
+        es: "Se han habilitado notificaciones de estado genérico",
+        pl: "Statystyki genetyczne umożliwiły",
+        uk: "Увімкнути повідомлення про статус",
+        "zh-cn": "基因身份通知使得",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  "Mqtt.clientId": {
+    mqtt: {
+      http_publish: "/rpc/Mqtt.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).client_id : undefined,
+    },
+    common: {
+      name: {
+        en: "Client ID",
+        de: "Client-ID",
+        ru: "ID клиента",
+        pt: "ID do cliente",
+        nl: "Cliënt ID",
+        fr: "ID client",
+        it: "ID cliente",
+        es: "ID de cliente",
+        pl: "Klient Ident",
+        uk: "Клієнт",
+        "zh-cn": "客户",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  "Cloud.enabled": {
+    mqtt: {
+      http_publish: `/rpc/Cloud.GetConfig`,
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value)?.enable : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Cloud.SetConfig",
+          params: { config: { enable: value } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Cloud Connection",
+        de: "Cloud-Verbindung",
+        ru: "Облачное соединение",
+        pt: "Conexão de nuvem",
+        nl: "Cloud Connection",
+        fr: "Cloud Connection",
+        it: "Connessione cloud",
+        es: "Cloud Connection",
+        pl: "Cloud Connection",
+        uk: "Хмарне підключення",
+        "zh-cn": "Cloud Connection",
+      },
+      type: "boolean",
+      role: "switch.enable",
+      read: true,
+      write: true,
+    },
+  },
+  "BLE.Event": {
+    mqtt: {
+      mqtt_publish: `<mqttprefix>/events/ble`,
+      mqtt_publish_funct: (value, self) => {
+        try {
+          const val = JSON.parse(value);
+
+          self.adapter.processBleMessage(val);
+          return JSON.stringify(val.payload, null, 2);
+        } catch (err) {
+          return JSON.stringify({ error: "Unable to parse json" });
+        }
+      },
+    },
+    common: {
+      name: "BLE JSON-Payload (experimental!)",
+      desc: "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
+      type: "string",
+      role: "json",
+      read: true,
+      write: false,
+    },
+  },
+};
+
+/**
+ * Default, used for all Shelly devices Gen 3
+ * https://shelly-api-docs.shelly.cloud/gen2/ - aktuell ist der einzige Unterschied zwischen gen2 und gen3 der schnellere Prozessor --> Vorbereitung auf Matter und IPv6
+ */
+const defaultsgen3 = {
+  gen: {
+    mqtt: {
+      init_funct: (self) => self.getDeviceGen(),
+    },
+    common: {
+      name: {
+        en: "Device generation",
+        de: "Gerätegeneration",
+        ru: "Генерация устройства",
+        pt: "Geração de dispositivos",
+        nl: "Vernietigingsgeneratie",
+        fr: "Production d'appareils",
+        it: "Generazione di dispositivi",
+        es: "Generación de dispositivos",
+        pl: "Pokolenie Device",
+        uk: "Виробництво",
+        "zh-cn": "代 人",
+      },
+      type: "number",
+      role: "state",
+      read: true,
+      write: false,
+      states: {
+        1: "Generation 1",
+        2: "Generation 2",
+        3: "Generation 3",
+      },
+    },
+  },
+  online: {
+    mqtt: {
+      init_funct: (self) => self.isOnline(),
+    },
+    common: {
+      name: {
+        en: "Device online",
+        de: "Gerät online",
+        ru: "Устройство онлайн",
+        pt: "Dispositivo online",
+        nl: "Device online",
+        fr: "Appareil en ligne",
+        it: "Dispositivo online",
+        es: "Dispositivo en línea",
+        pl: "Device online",
+        uk: "Пристрої онлайн",
+        "zh-cn": "网上证人",
+      },
+      type: "boolean",
+      role: "indicator.reachable",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("wifi"),
+    },
+  },
+  firmware: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetStatus",
+      http_publish_funct: (value) => {
+        /*
+                "sys": {
+                    ...
+                    "available_updates": {
+                        "stable": {
+                            "version": "0.13.0"
+                        }
                     }
                 }
+                */
+        if (value) {
+          const valueObj = JSON.parse(value);
+          if (valueObj?.sys?.available_updates?.stable?.version) {
+            return true;
+          }
+        }
 
-                return false;
-            },
-        },
-        common: {
-            name: {
-                en: 'New firmware available',
-                de: 'Neue Firmware verfügbar',
-                ru: 'Новая прошивка доступна',
-                pt: 'Novo firmware disponível',
-                nl: 'Nieuwe firmaware',
-                fr: 'Nouveau firmware disponible',
-                it: 'Nuovo firmware disponibile',
-                es: 'Nuevo firmware disponible',
-                pl: 'Nowy sprzęt',
-                uk: 'Нова прошивка доступна',
-                'zh-cn': '新的警觉',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+        return false;
+      },
     },
-    'firmwareupdate': {
-        mqtt: {
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Shelly.Update', params: { stage: 'stable' } }); },
-        },
-        common: {
-            name: {
-                en: 'Update firmware version',
-                de: 'Firmware-Version aktualisieren',
-                ru: 'Обновление версии прошивки',
-                pt: 'Atualizar versão de firmware',
-                nl: 'Update firmaware',
-                fr: 'Update firmware version',
-                it: 'Versione firmware di aggiornamento',
-                es: 'Actualizar la versión de firmware',
-                pl: 'Oficjalna strona',
-                uk: 'Оновлення версії прошивки',
-                'zh-cn': '最新软件版本',
-            },
-            type: 'boolean',
-            role: 'button',
-            read: false,
-            write: true,
-            icon: shellyHelper.getIcon('update'),
-        },
+    common: {
+      name: {
+        en: "New firmware available",
+        de: "Neue Firmware verfügbar",
+        ru: "Новая прошивка доступна",
+        pt: "Novo firmware disponível",
+        nl: "Nieuwe firmaware",
+        fr: "Nouveau firmware disponible",
+        it: "Nuovo firmware disponibile",
+        es: "Nuevo firmware disponible",
+        pl: "Nowy sprzęt",
+        uk: "Нова прошивка доступна",
+        "zh-cn": "新的警觉",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
     },
-    'uptime': {
-        mqtt: {
-            http_publish: '/rpc/Shelly.GetStatus',
-            http_publish_funct: value => value ? parseInt(JSON.parse(value).sys.uptime) : undefined,
-        },
-        common: {
-            name: {
-                en: 'Device running since',
-                de: 'Gerät läuft seit',
-                ru: 'Устройство работает с',
-                pt: 'Dispositivo em execução desde',
-                nl: 'Device vlucht sinds',
-                fr: 'Appareils fonctionnant depuis',
-                it: 'Dispositivo in esecuzione da',
-                es: 'Dispositivo funcionando desde',
-                pl: 'Device biegnie od czasu do czasu',
-                uk: 'Пристрої, що працюють з',
-                'zh-cn': '自那时以来丧失能力',
-            },
-            type: 'number',
-            role: 'value.interval',
-            unit: 'sec',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('clock'),
-        },
+  },
+  firmwareupdate: {
+    mqtt: {
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Shelly.Update",
+          params: { stage: "stable" },
+        });
+      },
     },
-    'version': {
-        mqtt: {
-            http_publish: '/rpc/Shelly.GetDeviceInfo',
-            http_publish_funct: value => value ? JSON.parse(value).fw_id : undefined,
-        },
-        common: {
-            name: {
-                en: 'Firmware version',
-                de: 'Firmware-Version',
-                ru: 'Версия прошивки',
-                pt: 'Versão de firmware',
-                nl: 'Firmware',
-                fr: 'Firmware version',
-                it: 'Versione firmware',
-                es: 'Versión de firmware',
-                pl: 'Okładka',
-                uk: 'Версія прошивки',
-                'zh-cn': '导 言',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('chip'),
-        },
+    common: {
+      name: {
+        en: "Update firmware version",
+        de: "Firmware-Version aktualisieren",
+        ru: "Обновление версии прошивки",
+        pt: "Atualizar versão de firmware",
+        nl: "Update firmaware",
+        fr: "Update firmware version",
+        it: "Versione firmware di aggiornamento",
+        es: "Actualizar la versión de firmware",
+        pl: "Oficjalna strona",
+        uk: "Оновлення версії прошивки",
+        "zh-cn": "最新软件版本",
+      },
+      type: "boolean",
+      role: "button",
+      read: false,
+      write: true,
+      icon: shellyHelper.getIcon("update"),
     },
-    'hostname': {
-        mqtt: {
-            init_funct: self => self.getIP(),
-        },
-        common: {
-            name: {
-                en: 'Device IP address or hostname',
-                de: 'Geräte-IP-Adresse oder Hostname',
-                ru: 'IP-адрес устройства или имя хоста',
-                pt: 'Endereço IP do dispositivo ou nome de host',
-                nl: 'IP-adres of gastnaam',
-                fr: 'Adresse IP ou nom d\'hôte',
-                it: 'Indirizzo IP del dispositivo o nome host',
-                es: 'Dirección IP o nombre de host',
-                pl: 'Adres IP lub hostname',
-                uk: 'Пристрої IP адреси або ім\'я користувача',
-                'zh-cn': '設備 IP 地址或主機名',
-            },
-            type: 'string',
-            role: 'info.ip',
-            read: true,
-            write: false,
-        },
+  },
+  uptime: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetStatus",
+      http_publish_funct: (value) =>
+        value ? parseInt(JSON.parse(value).sys.uptime) : undefined,
     },
-    'id': {
-        mqtt: {
-            init_funct: self => self.getDeviceId(),
-        },
-        common: {
-            name: {
-                en: 'Device ID',
-                de: 'Gerätekennung',
-                ru: 'ID устройства',
-                pt: 'ID do dispositivo',
-                nl: 'Device ID',
-                fr: 'ID',
-                it: 'ID dispositivo',
-                es: 'ID de dispositivo',
-                pl: 'ID',
-                uk: 'Ідентифікатор пристрою',
-                'zh-cn': '設備ID',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+    common: {
+      name: {
+        en: "Device running since",
+        de: "Gerät läuft seit",
+        ru: "Устройство работает с",
+        pt: "Dispositivo em execução desde",
+        nl: "Device vlucht sinds",
+        fr: "Appareils fonctionnant depuis",
+        it: "Dispositivo in esecuzione da",
+        es: "Dispositivo funcionando desde",
+        pl: "Device biegnie od czasu do czasu",
+        uk: "Пристрої, що працюють з",
+        "zh-cn": "自那时以来丧失能力",
+      },
+      type: "number",
+      role: "value.interval",
+      unit: "sec",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("clock"),
     },
-    'class': {
-        mqtt: {
-            init_funct: self => self.getDeviceClass(),
-        },
-        common: {
-            name: {
-                en: 'Device class',
-                de: 'Geräteklasse',
-                ru: 'Класс устройства',
-                pt: 'Classe de dispositivo',
-                nl: 'Device klas',
-                fr: 'Classe d\' appareil',
-                it: 'Classe di dispositivo',
-                es: 'Clase de dispositivo',
-                pl: 'Klasa Device',
-                uk: 'Клас пристрою',
-                'zh-cn': '证人阶级',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+  },
+  version: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetDeviceInfo",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).fw_id : undefined,
     },
-    'type': {
-        mqtt: {
-            init_funct: self => self.getDeviceType(),
-        },
-        common: {
-            name: {
-                en: 'Device type',
-                de: 'Gerätetyp',
-                ru: 'Тип устройства',
-                pt: 'Tipo de dispositivo',
-                nl: 'Device type',
-                fr: 'Type de dispositif',
-                it: 'Tipo di dispositivo',
-                es: 'Tipo de dispositivo',
-                pl: 'Device type',
-                uk: 'Тип пристрою',
-                'zh-cn': '設備類型',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+    common: {
+      name: {
+        en: "Firmware version",
+        de: "Firmware-Version",
+        ru: "Версия прошивки",
+        pt: "Versão de firmware",
+        nl: "Firmware",
+        fr: "Firmware version",
+        it: "Versione firmware",
+        es: "Versión de firmware",
+        pl: "Okładka",
+        uk: "Версія прошивки",
+        "zh-cn": "导 言",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("chip"),
     },
-    'model': {
-        mqtt: {
-            http_publish: '/rpc/Shelly.GetDeviceInfo',
-            http_publish_funct: value => value ? JSON.parse(value).model : undefined,
-        },
-        common: {
-            name: {
-                en: 'Device model',
-                de: 'Gerätemodell',
-                ru: 'Модель устройства',
-                pt: 'Modelo de dispositivo',
-                nl: 'Vernietig model',
-                fr: 'Modèle de dispositif',
-                it: 'Modello del dispositivo',
-                es: 'Modelo de dispositivo',
-                pl: 'Model',
-                uk: 'Модель пристрою',
-                'zh-cn': '证人模式',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+  },
+  hostname: {
+    mqtt: {
+      init_funct: (self) => self.getIP(),
     },
-    'knowledgeBaseUrl': {
-        mqtt: {
-            init_funct: self => self.getKnowledgeBaseUrl(),
-        },
-        common: {
-            name: {
-                en: 'Knowledge base',
-                de: 'Wissensdatenbank',
-                ru: 'База знаний',
-                pt: 'Base de conhecimento',
-                nl: 'Kennisbasis',
-                fr: 'Base de connaissances',
-                it: 'Base di conoscenza',
-                es: 'Base de conocimientos',
-                pl: 'Baza wiedzy',
-                uk: 'База знань',
-                'zh-cn': '知识基础',
-            },
-            type: 'string',
-            role: 'url.blank',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('question'),
-        },
+    common: {
+      name: {
+        en: "Device IP address or hostname",
+        de: "Geräte-IP-Adresse oder Hostname",
+        ru: "IP-адрес устройства или имя хоста",
+        pt: "Endereço IP do dispositivo ou nome de host",
+        nl: "IP-adres of gastnaam",
+        fr: "Adresse IP ou nom d'hôte",
+        it: "Indirizzo IP del dispositivo o nome host",
+        es: "Dirección IP o nombre de host",
+        pl: "Adres IP lub hostname",
+        uk: "Пристрої IP адреси або ім'я користувача",
+        "zh-cn": "設備 IP 地址或主機名",
+      },
+      type: "string",
+      role: "info.ip",
+      read: true,
+      write: false,
     },
-    'authEnabled': {
-        mqtt: {
-            http_publish: '/rpc/Shelly.GetDeviceInfo',
-            http_publish_funct: (value, self) => {
-                const authEnabled = value ? JSON.parse(value).auth_en : undefined;
+  },
+  id: {
+    mqtt: {
+      init_funct: (self) => self.getDeviceId(),
+    },
+    common: {
+      name: {
+        en: "Device ID",
+        de: "Gerätekennung",
+        ru: "ID устройства",
+        pt: "ID do dispositivo",
+        nl: "Device ID",
+        fr: "ID",
+        it: "ID dispositivo",
+        es: "ID de dispositivo",
+        pl: "ID",
+        uk: "Ідентифікатор пристрою",
+        "zh-cn": "設備ID",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  class: {
+    mqtt: {
+      init_funct: (self) => self.getDeviceClass(),
+    },
+    common: {
+      name: {
+        en: "Device class",
+        de: "Geräteklasse",
+        ru: "Класс устройства",
+        pt: "Classe de dispositivo",
+        nl: "Device klas",
+        fr: "Classe d' appareil",
+        it: "Classe di dispositivo",
+        es: "Clase de dispositivo",
+        pl: "Klasa Device",
+        uk: "Клас пристрою",
+        "zh-cn": "证人阶级",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  type: {
+    mqtt: {
+      init_funct: (self) => self.getDeviceType(),
+    },
+    common: {
+      name: {
+        en: "Device type",
+        de: "Gerätetyp",
+        ru: "Тип устройства",
+        pt: "Tipo de dispositivo",
+        nl: "Device type",
+        fr: "Type de dispositif",
+        it: "Tipo di dispositivo",
+        es: "Tipo de dispositivo",
+        pl: "Device type",
+        uk: "Тип пристрою",
+        "zh-cn": "設備類型",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  model: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetDeviceInfo",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).model : undefined,
+    },
+    common: {
+      name: {
+        en: "Device model",
+        de: "Gerätemodell",
+        ru: "Модель устройства",
+        pt: "Modelo de dispositivo",
+        nl: "Vernietig model",
+        fr: "Modèle de dispositif",
+        it: "Modello del dispositivo",
+        es: "Modelo de dispositivo",
+        pl: "Model",
+        uk: "Модель пристрою",
+        "zh-cn": "证人模式",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  knowledgeBaseUrl: {
+    mqtt: {
+      init_funct: (self) => self.getKnowledgeBaseUrl(),
+    },
+    common: {
+      name: {
+        en: "Knowledge base",
+        de: "Wissensdatenbank",
+        ru: "База знаний",
+        pt: "Base de conhecimento",
+        nl: "Kennisbasis",
+        fr: "Base de connaissances",
+        it: "Base di conoscenza",
+        es: "Base de conocimientos",
+        pl: "Baza wiedzy",
+        uk: "База знань",
+        "zh-cn": "知识基础",
+      },
+      type: "string",
+      role: "url.blank",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("question"),
+    },
+  },
+  authEnabled: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetDeviceInfo",
+      http_publish_funct: (value, self) => {
+        const authEnabled = value ? JSON.parse(value).auth_en : undefined;
 
-                if (!authEnabled && self.adapter.config.httppassword) {
-                    self.adapter.log.warn(`[authEnabled] ${self.getLogInfo()}: This device is not protected via restricted login (see adapter documentation for details)`);
-                }
+        if (!authEnabled && self.adapter.config.httppassword) {
+          self.adapter.log.warn(
+            `[authEnabled] ${self.getLogInfo()}: This device is not protected via restricted login (see adapter documentation for details)`
+          );
+        }
 
-                return authEnabled;
-            },
-        },
-        common: {
-            name: {
-                en: 'Authentication enabled',
-                de: 'Authentication aktiviert',
-                ru: 'Аутентификация включена',
-                pt: 'Autenticação activada',
-                nl: 'Authenticatie in staat',
-                fr: 'Authentification activée',
-                it: 'Autenticazione abilitata',
-                es: 'Autenticación habilitada',
-                pl: 'Authenticacja umożliwiła',
-                uk: 'Увімкнення аутентифікації',
-                'zh-cn': '逮捕使',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('auth'),
-        },
+        return authEnabled;
+      },
     },
-    'rssi': {
-        mqtt: {
-            http_publish: '/rpc/Shelly.GetStatus',
-            http_publish_funct: value => value ? JSON.parse(value).wifi.rssi : undefined,
-        },
-        common: {
-            name: {
-                en: 'Received Signal Strength Indication',
-                de: 'Empfangene Signalstärkeanzeige',
-                ru: 'Получена индикация силы сигнала',
-                pt: 'Indicação de Força de Sinal Recebida',
-                nl: 'Vervangde Signal Strength Indicatie',
-                fr: 'Indication de force de signal reçue',
-                it: 'Indicazione di forza segnale ricevuta',
-                es: 'Indicación de fuerza de la señal recibida',
-                pl: 'Received Signal Strength (ang.)',
-                uk: 'Отриманий показ сигналу',
-                'zh-cn': '接受签字国制',
-            },
-            type: 'number',
-            role: 'value',
-            unit: 'dBm',
-            read: true,
-            write: false,
-            icon: shellyHelper.getIcon('signal'),
-        },
+    common: {
+      name: {
+        en: "Authentication enabled",
+        de: "Authentication aktiviert",
+        ru: "Аутентификация включена",
+        pt: "Autenticação activada",
+        nl: "Authenticatie in staat",
+        fr: "Authentification activée",
+        it: "Autenticazione abilitata",
+        es: "Autenticación habilitada",
+        pl: "Authenticacja umożliwiła",
+        uk: "Увімкнення аутентифікації",
+        "zh-cn": "逮捕使",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("auth"),
     },
-    'reboot': {
-        mqtt: {
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Shelly.Reboot' }); },
-        },
-        common: {
-            name: {
-                en: 'Reboot',
-                de: 'Neustart',
-                ru: 'Перезагрузка',
-                pt: 'Reiniciar',
-                nl: 'Reboot',
-                fr: 'Reboot',
-                it: 'Reboot',
-                es: 'Reboot',
-                pl: 'Reboot',
-                uk: 'Перезавантаження',
-                'zh-cn': 'Reboot',
-            },
-            type: 'boolean',
-            role: 'button',
-            read: false,
-            write: true,
-        },
+  },
+  rssi: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetStatus",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).wifi.rssi : undefined,
     },
-    'protocol': {
-        mqtt: {
-            init_value: 'mqtt',
-        },
-        common: {
-            name: {
-                en: 'Protocol',
-                de: 'Protokoll',
-                ru: 'Протокол',
-                pt: 'Protocolo',
-                nl: 'Protocol',
-                fr: 'Protocole',
-                it: 'Protocollo',
-                es: 'Protocolo',
-                pl: 'Protokół',
-                uk: 'Протокол',
-                'zh-cn': '议定书',
-            },
-            type: 'string',
-            role: 'text',
-            read: true,
-            write: false,
-        },
+    common: {
+      name: {
+        en: "Received Signal Strength Indication",
+        de: "Empfangene Signalstärkeanzeige",
+        ru: "Получена индикация силы сигнала",
+        pt: "Indicação de Força de Sinal Recebida",
+        nl: "Vervangde Signal Strength Indicatie",
+        fr: "Indication de force de signal reçue",
+        it: "Indicazione di forza segnale ricevuta",
+        es: "Indicación de fuerza de la señal recibida",
+        pl: "Received Signal Strength (ang.)",
+        uk: "Отриманий показ сигналу",
+        "zh-cn": "接受签字国制",
+      },
+      type: "number",
+      role: "value",
+      unit: "dBm",
+      read: true,
+      write: false,
+      icon: shellyHelper.getIcon("signal"),
     },
-    'name': {
-        mqtt: {
-            http_publish: '/rpc/Shelly.GetDeviceInfo',
-            http_publish_funct: async (value, self) => value ? await shellyHelper.setDeviceName(self, JSON.parse(value).name) : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Sys.SetConfig', params: { config: { device: { name: value } } } }); },
-        },
-        common: {
-            name: {
-                en: 'Device name',
-                de: 'Bezeichnung des Geräts',
-                ru: 'Наименование устройства',
-                pt: 'Nome do dispositivo',
-                nl: 'Devicenaam',
-                fr: 'Nom du dispositif',
-                it: 'Nome del dispositivo',
-                es: 'Nombre del dispositivo',
-                pl: 'Device name',
-                uk: 'Назва пристрою',
-                'zh-cn': '证人姓名',
-            },
-            type: 'string',
-            role: 'info.name',
-            read: true,
-            write: true,
-            icon: shellyHelper.getIcon('signature'),
-        },
+  },
+  reboot: {
+    mqtt: {
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Shelly.Reboot",
+        });
+      },
     },
-    'Sys.eco': {
-        mqtt: {
-            http_publish: '/rpc/Sys.GetConfig',
-            http_publish_funct: value => value ? JSON.parse(value).device.eco_mode : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Sys.SetConfig', params: { config: { device: { eco_mode: value } } } }); },
-        },
-        common: {
-            name: {
-                en: 'Eco Mode',
-                de: 'Eco-Modus',
-                ru: 'Эко режим',
-                pt: 'Modo Eco',
-                nl: 'Eco Mode',
-                fr: 'Eco Mode',
-                it: 'Modalità Eco',
-                es: 'Eco Mode',
-                pl: 'Eko',
-                uk: 'Еко режим',
-                'zh-cn': 'Eco Mode',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: true,
-        },
+    common: {
+      name: {
+        en: "Reboot",
+        de: "Neustart",
+        ru: "Перезагрузка",
+        pt: "Reiniciar",
+        nl: "Reboot",
+        fr: "Reboot",
+        it: "Reboot",
+        es: "Reboot",
+        pl: "Reboot",
+        uk: "Перезавантаження",
+        "zh-cn": "Reboot",
+      },
+      type: "boolean",
+      role: "button",
+      read: false,
+      write: true,
     },
-    'Sys.sntp': {
-        mqtt: {
-            http_publish: '/rpc/Sys.GetConfig',
-            http_publish_funct: value => value ? JSON.parse(value).sntp.server : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Sys.SetConfig', params: { config: { sntp: { server: value } } } }); },
-        },
-        common: {
-            name: {
-                en: 'SNTP Server',
-                de: 'SNTP Server',
-                ru: 'SNTP сервер',
-                pt: 'Servidor SNTP',
-                nl: 'SNTP',
-                fr: 'SNTP Server',
-                it: 'Server SNTP',
-                es: 'SNTP Server',
-                pl: 'SNTP Server',
-                uk: 'Статус на сервери',
-                'zh-cn': 'SNTP Server',
-            },
-            type: 'string',
-            role: 'text.url',
-            read: true,
-            write: true,
-        },
+  },
+  protocol: {
+    mqtt: {
+      init_value: "mqtt",
     },
-    'Sys.timezone': {
-        mqtt: {
-            http_publish: '/rpc/Sys.GetConfig',
-            http_publish_funct: value => value ? JSON.parse(value).location.tz : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Sys.SetConfig', params: { config: { location: { tz: value } } } }); },
-        },
-        common: {
-            name: {
-                en: 'Timezone',
-                de: 'Zeitzone',
-                ru: 'Часовой пояс',
-                pt: 'Fuso horário',
-                nl: 'Tijdzone',
-                fr: 'Timezone',
-                it: 'Tempo',
-                es: 'Zona horaria',
-                pl: 'Timezone',
-                uk: 'Часовий пояс',
-                'zh-cn': '时间区',
-            },
-            type: 'string',
-            role: 'text',
-            read: true,
-            write: true,
-        },
+    common: {
+      name: {
+        en: "Protocol",
+        de: "Protokoll",
+        ru: "Протокол",
+        pt: "Protocolo",
+        nl: "Protocol",
+        fr: "Protocole",
+        it: "Protocollo",
+        es: "Protocolo",
+        pl: "Protokół",
+        uk: "Протокол",
+        "zh-cn": "议定书",
+      },
+      type: "string",
+      role: "text",
+      read: true,
+      write: false,
     },
-    'Sys.lat': {
-        mqtt: {
-            http_publish: '/rpc/Sys.GetConfig',
-            http_publish_funct: value => value ? JSON.parse(value).location.lat : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Sys.SetConfig', params: { config: { location: { lat: value } } } }); },
-        },
-        common: {
-            name: {
-                en: 'Latitude',
-                de: 'Breite',
-                ru: 'Широта',
-                pt: 'Latitude',
-                nl: 'Latitude',
-                fr: 'Latitude',
-                it: 'Latitudine',
-                es: 'Latitud',
-                pl: 'Latitudes',
-                uk: 'Прованс',
-                'zh-cn': '学历',
-            },
-            type: 'number',
-            role: 'value.gps.latitude',
-            read: true,
-            write: true,
-        },
+  },
+  name: {
+    mqtt: {
+      http_publish: "/rpc/Shelly.GetDeviceInfo",
+      http_publish_funct: async (value, self) =>
+        value
+          ? await shellyHelper.setDeviceName(self, JSON.parse(value).name)
+          : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { device: { name: value } } },
+        });
+      },
     },
-    'Sys.lon': {
-        mqtt: {
-            http_publish: '/rpc/Sys.GetConfig',
-            http_publish_funct: value => value ? JSON.parse(value).location.lon : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Sys.SetConfig', params: { config: { location: { lon: value } } } }); },
-        },
-        common: {
-            name: {
-                en: 'Longitude',
-                de: 'Länge',
-                ru: 'Долгота',
-                pt: 'Longitude',
-                nl: 'Longit',
-                fr: 'Longitude',
-                it: 'Longitudine',
-                es: 'Longitud',
-                pl: 'Długość',
-                uk: 'Довгий',
-                'zh-cn': '长 度',
-            },
-            type: 'number',
-            role: 'value.gps.longitude',
-            read: true,
-            write: true,
-        },
+    common: {
+      name: {
+        en: "Device name",
+        de: "Bezeichnung des Geräts",
+        ru: "Наименование устройства",
+        pt: "Nome do dispositivo",
+        nl: "Devicenaam",
+        fr: "Nom du dispositif",
+        it: "Nome del dispositivo",
+        es: "Nombre del dispositivo",
+        pl: "Device name",
+        uk: "Назва пристрою",
+        "zh-cn": "证人姓名",
+      },
+      type: "string",
+      role: "info.name",
+      read: true,
+      write: true,
+      icon: shellyHelper.getIcon("signature"),
     },
-    'Sys.debugEnabled': {
-        mqtt: {
-            http_publish: '/rpc/Sys.GetConfig',
-            http_publish_funct: value => value ? JSON.parse(value).debug.mqtt.enable : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Sys.SetConfig', params: { config: { debug: { mqtt: { enable: value } } } } }); },
-        },
-        common: {
-            name: {
-                en: 'Debug mode',
-                de: 'Debug-Modus',
-                ru: 'Режим Debug',
-                pt: 'Modo de depuração',
-                nl: 'Debug mode',
-                fr: 'Mode Debug',
-                it: 'Modalità Debug',
-                es: 'Modo de depuración',
-                pl: 'Tryb debugowania',
-                uk: 'Режим Debug',
-                'zh-cn': 'Dbug模式',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: true,
-        },
+  },
+  "Sys.eco": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).device.eco_mode : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { device: { eco_mode: value } } },
+        });
+      },
     },
-    'WiFi.apEnabled': {
-        mqtt: {
-            http_publish: '/rpc/WiFi.GetConfig',
-            http_publish_funct: value => value ? JSON.parse(value).ap.enable : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'WiFi.SetConfig', params: { config: { ap: { enable: value } } } }); },
-        },
-        common: {
-            name: {
-                en: 'Access point enabled',
-                de: 'Access Point aktiviert',
-                ru: 'Доступ к точке включен',
-                pt: 'Ponto de acesso habilitado',
-                nl: 'Toegangspunt in staat',
-                fr: 'Point d \' accès activé',
-                it: 'Punto di accesso abilitato',
-                es: 'Punto de acceso habilitado',
-                pl: 'Punkt dostępu umożliwiał',
-                uk: 'Увімкнути точку доступу',
-                'zh-cn': '进入点',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: true,
-        },
+    common: {
+      name: {
+        en: "Eco Mode",
+        de: "Eco-Modus",
+        ru: "Эко режим",
+        pt: "Modo Eco",
+        nl: "Eco Mode",
+        fr: "Eco Mode",
+        it: "Modalità Eco",
+        es: "Eco Mode",
+        pl: "Eko",
+        uk: "Еко режим",
+        "zh-cn": "Eco Mode",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: true,
     },
-    'Mqtt.topicPrefix': {
-        mqtt: {
-            http_publish: '/rpc/Mqtt.GetConfig',
-            http_publish_funct: (value, self) => {
-                const result = value ? JSON.parse(value).topic_prefix : undefined;
-                if (result && self.getMqttPrefix() && result !== self.getMqttPrefix()) {
-                    self.adapter.log.warn(`[Mqtt.topicPrefix] ${self.getLogInfo()}: Configured mqtt topic prefix "${result}" and actual topic prefix "${self.getMqttPrefix()}" do not match. Please check configuration`);
-                }
+  },
+  "Sys.sntp": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).sntp.server : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { sntp: { server: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "SNTP Server",
+        de: "SNTP Server",
+        ru: "SNTP сервер",
+        pt: "Servidor SNTP",
+        nl: "SNTP",
+        fr: "SNTP Server",
+        it: "Server SNTP",
+        es: "SNTP Server",
+        pl: "SNTP Server",
+        uk: "Статус на сервери",
+        "zh-cn": "SNTP Server",
+      },
+      type: "string",
+      role: "text.url",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.timezone": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).location.tz : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { location: { tz: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Timezone",
+        de: "Zeitzone",
+        ru: "Часовой пояс",
+        pt: "Fuso horário",
+        nl: "Tijdzone",
+        fr: "Timezone",
+        it: "Tempo",
+        es: "Zona horaria",
+        pl: "Timezone",
+        uk: "Часовий пояс",
+        "zh-cn": "时间区",
+      },
+      type: "string",
+      role: "text",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.lat": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).location.lat : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { location: { lat: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Latitude",
+        de: "Breite",
+        ru: "Широта",
+        pt: "Latitude",
+        nl: "Latitude",
+        fr: "Latitude",
+        it: "Latitudine",
+        es: "Latitud",
+        pl: "Latitudes",
+        uk: "Прованс",
+        "zh-cn": "学历",
+      },
+      type: "number",
+      role: "value.gps.latitude",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.lon": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).location.lon : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { location: { lon: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Longitude",
+        de: "Länge",
+        ru: "Долгота",
+        pt: "Longitude",
+        nl: "Longit",
+        fr: "Longitude",
+        it: "Longitudine",
+        es: "Longitud",
+        pl: "Długość",
+        uk: "Довгий",
+        "zh-cn": "长 度",
+      },
+      type: "number",
+      role: "value.gps.longitude",
+      read: true,
+      write: true,
+    },
+  },
+  "Sys.debugEnabled": {
+    mqtt: {
+      http_publish: "/rpc/Sys.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).debug.mqtt.enable : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Sys.SetConfig",
+          params: { config: { debug: { mqtt: { enable: value } } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Debug mode",
+        de: "Debug-Modus",
+        ru: "Режим Debug",
+        pt: "Modo de depuração",
+        nl: "Debug mode",
+        fr: "Mode Debug",
+        it: "Modalità Debug",
+        es: "Modo de depuración",
+        pl: "Tryb debugowania",
+        uk: "Режим Debug",
+        "zh-cn": "Dbug模式",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: true,
+    },
+  },
+  "WiFi.apEnabled": {
+    mqtt: {
+      http_publish: "/rpc/WiFi.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).ap.enable : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "WiFi.SetConfig",
+          params: { config: { ap: { enable: value } } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Access point enabled",
+        de: "Access Point aktiviert",
+        ru: "Доступ к точке включен",
+        pt: "Ponto de acesso habilitado",
+        nl: "Toegangspunt in staat",
+        fr: "Point d ' accès activé",
+        it: "Punto di accesso abilitato",
+        es: "Punto de acceso habilitado",
+        pl: "Punkt dostępu umożliwiał",
+        uk: "Увімкнути точку доступу",
+        "zh-cn": "进入点",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: true,
+    },
+  },
+  "Mqtt.topicPrefix": {
+    mqtt: {
+      http_publish: "/rpc/Mqtt.GetConfig",
+      http_publish_funct: (value, self) => {
+        const result = value ? JSON.parse(value).topic_prefix : undefined;
+        if (result && self.getMqttPrefix() && result !== self.getMqttPrefix()) {
+          self.adapter.log.warn(
+            `[Mqtt.topicPrefix] ${self.getLogInfo()}: Configured mqtt topic prefix "${result}" and actual topic prefix "${self.getMqttPrefix()}" do not match. Please check configuration`
+          );
+        }
 
-                return result;
-            },
-        },
-        common: {
-            name: {
-                en: 'Topic prefix',
-                de: 'Thema Präfix',
-                ru: 'Тема префикса',
-                pt: 'Prefixo de tópico',
-                nl: 'Onderwerp voorvoegsel',
-                fr: 'Préfixe du sujet',
-                it: 'Prefisso tematico',
-                es: 'Prefijo temático',
-                pl: 'Przedrostek',
-                uk: 'Тема префікса',
-                'zh-cn': '主题前',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+        return result;
+      },
     },
-    'Mqtt.rpcNotifications': {
-        mqtt: {
-            http_publish: '/rpc/Mqtt.GetConfig',
-            http_publish_funct: (value, self) => {
-                const result = value ? JSON.parse(value).rpc_ntf : undefined;
-                if (result === false) {
-                    self.adapter.log.warn(`[Mqtt.rpcNotifications] ${self.getLogInfo()}: "RPC Status Notifications" are disabled (see adapter documentation for details)`);
-                }
+    common: {
+      name: {
+        en: "Topic prefix",
+        de: "Thema Präfix",
+        ru: "Тема префикса",
+        pt: "Prefixo de tópico",
+        nl: "Onderwerp voorvoegsel",
+        fr: "Préfixe du sujet",
+        it: "Prefisso tematico",
+        es: "Prefijo temático",
+        pl: "Przedrostek",
+        uk: "Тема префікса",
+        "zh-cn": "主题前",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  "Mqtt.rpcNotifications": {
+    mqtt: {
+      http_publish: "/rpc/Mqtt.GetConfig",
+      http_publish_funct: (value, self) => {
+        const result = value ? JSON.parse(value).rpc_ntf : undefined;
+        if (result === false) {
+          self.adapter.log.warn(
+            `[Mqtt.rpcNotifications] ${self.getLogInfo()}: "RPC Status Notifications" are disabled (see adapter documentation for details)`
+          );
+        }
 
-                return result;
-            },
-        },
-        common: {
-            name: {
-                en: 'RPC status notifications enabled',
-                de: 'RPC-Statusmeldungen aktiviert',
-                ru: 'Уведомления о состоянии RPC включены',
-                pt: 'Notificações de status RPC habilitado',
-                nl: 'RPC status melding',
-                fr: 'Notifications de statut RPC activées',
-                it: 'Notifiche di stato RPC abilitate',
-                es: 'Se han habilitado notificaciones de la categoría RPC',
-                pl: 'Statystyki RPC',
-                uk: 'Повідомлення про статус РПК ввімкнено',
-                'zh-cn': '方案执行情况通知',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+        return result;
+      },
     },
-    'Mqtt.statusNotifications': {
-        mqtt: {
-            http_publish: '/rpc/Mqtt.GetConfig',
-            http_publish_funct: (value, self) => {
-                const result = value ? JSON.parse(value).status_ntf : undefined;
-                if (result === false) {
-                    self.adapter.log.warn(`[Mqtt.statusNotifications] ${self.getLogInfo()}: "General Status Notifications" are disabled (see adapter documentation for details)`);
-                }
+    common: {
+      name: {
+        en: "RPC status notifications enabled",
+        de: "RPC-Statusmeldungen aktiviert",
+        ru: "Уведомления о состоянии RPC включены",
+        pt: "Notificações de status RPC habilitado",
+        nl: "RPC status melding",
+        fr: "Notifications de statut RPC activées",
+        it: "Notifiche di stato RPC abilitate",
+        es: "Se han habilitado notificaciones de la categoría RPC",
+        pl: "Statystyki RPC",
+        uk: "Повідомлення про статус РПК ввімкнено",
+        "zh-cn": "方案执行情况通知",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  "Mqtt.statusNotifications": {
+    mqtt: {
+      http_publish: "/rpc/Mqtt.GetConfig",
+      http_publish_funct: (value, self) => {
+        const result = value ? JSON.parse(value).status_ntf : undefined;
+        if (result === false) {
+          self.adapter.log.warn(
+            `[Mqtt.statusNotifications] ${self.getLogInfo()}: "General Status Notifications" are disabled (see adapter documentation for details)`
+          );
+        }
 
-                return result;
-            },
-        },
-        common: {
-            name: {
-                en: 'Generic status notifications enabled',
-                de: 'Generelle Statusmeldungen aktiviert',
-                ru: 'Уведомления о генерическом статусе включены',
-                pt: 'Notificações de status genéricas activadas',
-                nl: 'Generische status melding',
-                fr: 'Notifications d\'état générique activé',
-                it: 'Notifiche di stato generiche abilitate',
-                es: 'Se han habilitado notificaciones de estado genérico',
-                pl: 'Statystyki genetyczne umożliwiły',
-                uk: 'Увімкнути повідомлення про статус',
-                'zh-cn': '基因身份通知使得',
-            },
-            type: 'boolean',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+        return result;
+      },
     },
-    'Mqtt.clientId': {
-        mqtt: {
-            http_publish: '/rpc/Mqtt.GetConfig',
-            http_publish_funct: value => value ? JSON.parse(value).client_id : undefined,
-        },
-        common: {
-            name: {
-                en: 'Client ID',
-                de: 'Client-ID',
-                ru: 'ID клиента',
-                pt: 'ID do cliente',
-                nl: 'Cliënt ID',
-                fr: 'ID client',
-                it: 'ID cliente',
-                es: 'ID de cliente',
-                pl: 'Klient Ident',
-                uk: 'Клієнт',
-                'zh-cn': '客户',
-            },
-            type: 'string',
-            role: 'state',
-            read: true,
-            write: false,
-        },
+    common: {
+      name: {
+        en: "Generic status notifications enabled",
+        de: "Generelle Statusmeldungen aktiviert",
+        ru: "Уведомления о генерическом статусе включены",
+        pt: "Notificações de status genéricas activadas",
+        nl: "Generische status melding",
+        fr: "Notifications d'état générique activé",
+        it: "Notifiche di stato generiche abilitate",
+        es: "Se han habilitado notificaciones de estado genérico",
+        pl: "Statystyki genetyczne umożliwiły",
+        uk: "Увімкнути повідомлення про статус",
+        "zh-cn": "基因身份通知使得",
+      },
+      type: "boolean",
+      role: "state",
+      read: true,
+      write: false,
     },
-    'Cloud.enabled': {
-        mqtt: {
-            http_publish: `/rpc/Cloud.GetConfig`,
-            http_publish_funct: value => value ? JSON.parse(value)?.enable : undefined,
-            mqtt_cmd: '<mqttprefix>/rpc',
-            mqtt_cmd_funct: (value, self) => { return JSON.stringify({ id: self.getNextMsgId(), src: 'iobroker', method: 'Cloud.SetConfig', params: { config: { enable: value } } }); },
-        },
-        common: {
-            name: {
-                en: 'Cloud Connection',
-                de: 'Cloud-Verbindung',
-                ru: 'Облачное соединение',
-                pt: 'Conexão de nuvem',
-                nl: 'Cloud Connection',
-                fr: 'Cloud Connection',
-                it: 'Connessione cloud',
-                es: 'Cloud Connection',
-                pl: 'Cloud Connection',
-                uk: 'Хмарне підключення',
-                'zh-cn': 'Cloud Connection',
-            },
-            type: 'boolean',
-            role: 'switch.enable',
-            read: true,
-            write: true,
-        },
+  },
+  "Mqtt.clientId": {
+    mqtt: {
+      http_publish: "/rpc/Mqtt.GetConfig",
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value).client_id : undefined,
     },
-    'BLE.Event': {
-        mqtt: {
-            mqtt_publish: `<mqttprefix>/events/ble`,
-            mqtt_publish_funct: (value, self) => {
-                try {
-                    const val = JSON.parse(value);
+    common: {
+      name: {
+        en: "Client ID",
+        de: "Client-ID",
+        ru: "ID клиента",
+        pt: "ID do cliente",
+        nl: "Cliënt ID",
+        fr: "ID client",
+        it: "ID cliente",
+        es: "ID de cliente",
+        pl: "Klient Ident",
+        uk: "Клієнт",
+        "zh-cn": "客户",
+      },
+      type: "string",
+      role: "state",
+      read: true,
+      write: false,
+    },
+  },
+  "Cloud.enabled": {
+    mqtt: {
+      http_publish: `/rpc/Cloud.GetConfig`,
+      http_publish_funct: (value) =>
+        value ? JSON.parse(value)?.enable : undefined,
+      mqtt_cmd: "<mqttprefix>/rpc",
+      mqtt_cmd_funct: (value, self) => {
+        return JSON.stringify({
+          id: self.getNextMsgId(),
+          src: "iobroker",
+          method: "Cloud.SetConfig",
+          params: { config: { enable: value } },
+        });
+      },
+    },
+    common: {
+      name: {
+        en: "Cloud Connection",
+        de: "Cloud-Verbindung",
+        ru: "Облачное соединение",
+        pt: "Conexão de nuvem",
+        nl: "Cloud Connection",
+        fr: "Cloud Connection",
+        it: "Connessione cloud",
+        es: "Cloud Connection",
+        pl: "Cloud Connection",
+        uk: "Хмарне підключення",
+        "zh-cn": "Cloud Connection",
+      },
+      type: "boolean",
+      role: "switch.enable",
+      read: true,
+      write: true,
+    },
+  },
+  "BLE.Event": {
+    mqtt: {
+      mqtt_publish: `<mqttprefix>/events/ble`,
+      mqtt_publish_funct: (value, self) => {
+        try {
+          const val = JSON.parse(value);
 
-                    self.adapter.processBleMessage(val);
-                    return JSON.stringify(val.payload, null, 2);
-                } catch (err) {
-                    return JSON.stringify({ error: 'Unable to parse json' });
-                }
-            },
-        },
-        common: {
-            name: 'BLE JSON-Payload (experimental!)',
-            desc: 'Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md',
-            type: 'string',
-            role: 'json',
-            read: true,
-            write: false,
-        },
+          self.adapter.processBleMessage(val);
+          return JSON.stringify(val.payload, null, 2);
+        } catch (err) {
+          return JSON.stringify({ error: "Unable to parse json" });
+        }
+      },
     },
+    common: {
+      name: "BLE JSON-Payload (experimental!)",
+      desc: "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
+      type: "string",
+      role: "json",
+      read: true,
+      write: false,
+    },
+  },
 };
 
 module.exports = {
-    defaultsgen1,
-    defaultsgen2,
+  defaultsgen1,
+  defaultsgen2,
+  defaultsgen3,
 };

--- a/lib/devices/gen3-helper.js
+++ b/lib/devices/gen3-helper.js
@@ -1,0 +1,2383 @@
+'use strict';
+
+const shellyHelper = require('../shelly-helper');
+
+/**
+ * Adds a generic switch definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} switchId
+ */
+function addPM1ToGen3Device(deviceObj, switchId) {
+
+    deviceObj[`PM1:${switchId}.Power`] = {
+        device_mode: 'pm1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).apower,
+        },
+        common: {
+            name: 'Power',
+            type: 'number',
+            role: 'value.power',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'W',
+        },
+    };
+
+    deviceObj[`PM1:${switchId}.Voltage`] = {
+        device_mode: 'pm1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).voltage,
+        },
+        common: {
+            name: {
+                en: 'Voltage',
+                de: 'Spannung',
+                ru: 'Напряжение',
+                pt: 'Tensão',
+                nl: 'Voltage',
+                fr: 'Tension',
+                it: 'Tensione',
+                es: 'Voltaje',
+                pl: 'Voltage',
+                'zh-cn': '动产',
+            },
+            type: 'number',
+            role: 'value.voltage',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'V',
+        },
+    };
+
+    deviceObj[`PM1:${switchId}.Current`] = {
+        device_mode: 'pm1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).current,
+        },
+        common: {
+            name: 'Current',
+            type: 'number',
+            role: 'value.current',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'A',
+        },
+    };
+
+    deviceObj[`PM1:${switchId}.Energy`] = {
+        device_mode: 'pm1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).aenergy.total,
+        },
+        common: {
+            name: 'Energy',
+            type: 'number',
+            role: 'value.power.consumption',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'Wh',
+        },
+    };
+
+    deviceObj[`PM1:${switchId}.Frequency`] = {
+        device_mode: 'pm1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).freq,
+        },
+        common: {
+            name: 'Frequenz',
+            type: 'number',
+            role: 'value.frequency',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'Hz',
+        },
+    };
+}
+/**
+ * Adds a generic Illuminance sensor definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} sensorId
+ */
+function addIlluminanceSensorToGen3Device(deviceObj, sensorId) {
+
+    deviceObj[`Illuminance${sensorId}.ChannelName`] = {
+        mqtt: {
+            http_publish: `/rpc/Illuminance.GetConfig?id=${sensorId}`,
+            http_publish_funct: async (value, self) => {
+                return value ? await shellyHelper.setChannelName(self, `Illuminance${sensorId}`, JSON.parse(value).name) : undefined;
+            },
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Illuminance.SetConfig',
+                    params: { id: sensorId, config: { name: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Channel name',
+                de: 'Kanalname',
+                ru: 'Имя канала',
+                pt: 'Nome do canal',
+                nl: 'Kanaalnaam',
+                fr: 'Nom du canal',
+                it: 'Nome del canale',
+                es: 'Nombre del canal',
+                pl: 'Channel imię',
+                'zh-cn': '姓名',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Illuminance${sensorId}.Lux`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/illuminance:${sensorId}`,
+            mqtt_publish_funct: value => JSON.parse(value).lux,
+        },
+        common: {
+            name: {
+                en: 'Illuminance',
+                de: 'Helligkeit',
+                ru: 'Освещенность',
+                pt: 'Iluminancia',
+                nl: 'Verlichtingssterkte',
+                fr: 'lumineuse',
+                it: 'Illuminazione',
+                es: 'Iluminancia',
+                pl: 'Podświetlenie',
+                'zh-cn': '照度',
+            },
+            type: 'number',
+            role: 'value.brightness',
+            read: true,
+            write: false,
+            unit: 'Lux',
+        },
+    };
+
+}
+
+/**
+ * Adds a generic switch definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} switchId
+ * @param {boolean} hasPowerMetering
+ */
+function addSwitchToGen3Device(deviceObj, switchId, hasPowerMetering) {
+
+    deviceObj[`Relay${switchId}.ChannelName`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: async (value, self) => {
+                return value ? await shellyHelper.setChannelName(self, `Relay${switchId}`, JSON.parse(value).name) : undefined;
+            },
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: { id: switchId, config: { name: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Channel name',
+                de: 'Kanalname',
+                ru: 'Имя канала',
+                pt: 'Nome do canal',
+                nl: 'Kanaalnaam',
+                fr: 'Nom du canal',
+                it: 'Nome del canale',
+                es: 'Nombre del canal',
+                pl: 'Channel imię',
+                'zh-cn': '姓名',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.Switch`] = {
+        device_mode: 'switch',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).output,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.Set',
+                    params: { id: switchId, on: value },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Switch',
+                de: 'Schalter',
+                ru: 'Переключить',
+                pt: 'Interruptor',
+                nl: 'Vertaling:',
+                fr: 'Interrupteur',
+                it: 'Interruttore',
+                es: 'Interruptor',
+                pl: 'Switch',
+                'zh-cn': '目 录',
+            },
+            type: 'boolean',
+            role: 'switch',
+            read: true,
+            write: true,
+            def: false,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.InputMode`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).in_mode : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: { id: switchId, config: { in_mode: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Input mode',
+                de: 'Eingangsmodus',
+                ru: 'Входной режим',
+                pt: 'Modo de entrada',
+                nl: 'Input modus',
+                fr: 'Mode d \' entrée',
+                it: 'Modalità di ingresso',
+                es: 'Modo de entrada',
+                pl: 'Tryb gry',
+                'zh-cn': '投入模式',
+            },
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: true,
+            states: {
+                'momentary': 'momentary',
+                'follow': 'follow',
+                'flip': 'flip',
+                'detached': 'detached',
+            },
+        },
+    };
+
+    deviceObj[`Relay${switchId}.InitialState`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).initial_state : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: { id: switchId, config: { initial_state: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Initial state',
+                de: 'Ausgangszustand',
+                ru: 'Начальное состояние',
+                pt: 'Estado inicial',
+                nl: 'Initiële staat',
+                fr: 'État initial',
+                it: 'Stato iniziale',
+                es: 'Estado inicial',
+                pl: 'Państwo inicjalne',
+                'zh-cn': '初次报告',
+            },
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: true,
+            states: {
+                'on': 'on',
+                'off': 'off',
+                'restore_last': 'restore_last',
+                'match_input': 'match_input',
+            },
+        },
+    };
+
+    deviceObj[`Relay${switchId}.AutoTimerOn`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).auto_on : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: { id: switchId, config: { auto_on: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Auto Timer On',
+            type: 'boolean',
+            role: 'switch.enable',
+            def: false,
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.AutoTimerOnDelay`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).auto_on_delay : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: { id: switchId, config: { auto_on_delay: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Auto Timer On Delay',
+            type: 'number',
+            role: 'level.timer',
+            def: 0,
+            unit: 's',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.AutoTimerOff`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).auto_off : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: { id: switchId, config: { auto_off: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Auto Timer Off',
+            type: 'boolean',
+            role: 'switch.enable',
+            def: false,
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.AutoTimerOffDelay`] = {
+        device_mode: 'switch',
+        mqtt: {
+            http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+            http_publish_funct: value => value ? JSON.parse(value).auto_off_delay : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Switch.SetConfig',
+                    params: { id: switchId, config: { auto_off_delay: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Auto Timer Off Delay',
+            type: 'number',
+            role: 'level.timer',
+            def: 0,
+            unit: 's',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.source`] = {
+        device_mode: 'switch',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).source,
+        },
+        common: {
+            name: {
+                en: 'Source of last command',
+                de: 'Quelle des letzten Befehls',
+                ru: 'Источник последней команды',
+                pt: 'Fonte do último comando',
+                nl: 'Vertaling:',
+                fr: 'Source de la dernière commande',
+                it: 'Fonte dell\'ultimo comando',
+                es: 'Fuente del último comando',
+                pl: 'Źródło ostatniego dowództwa',
+                'zh-cn': '最后一次指挥的来源',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: false,
+        },
+    };
+
+    deviceObj[`Relay${switchId}.temperatureC`] = {
+        device_mode: 'switch',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).temperature.tC,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°C',
+        },
+    };
+
+    deviceObj[`Relay${switchId}.temperatureF`] = {
+        device_mode: 'switch',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).temperature.tF,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°F',
+        },
+    };
+
+    if (hasPowerMetering) {
+
+        deviceObj[`Relay${switchId}.Power`] = {
+            device_mode: 'switch',
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+                mqtt_publish_funct: value => JSON.parse(value).apower,
+            },
+            common: {
+                name: 'Power',
+                type: 'number',
+                role: 'value.power',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'W',
+            },
+        };
+
+        deviceObj[`Relay${switchId}.Voltage`] = {
+            device_mode: 'switch',
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+                mqtt_publish_funct: value => JSON.parse(value).voltage,
+            },
+            common: {
+                name: {
+                    en: 'Voltage',
+                    de: 'Spannung',
+                    ru: 'Напряжение',
+                    pt: 'Tensão',
+                    nl: 'Voltage',
+                    fr: 'Tension',
+                    it: 'Tensione',
+                    es: 'Voltaje',
+                    pl: 'Voltage',
+                    'zh-cn': '动产',
+                },
+                type: 'number',
+                role: 'value.voltage',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'V',
+            },
+        };
+
+        deviceObj[`Relay${switchId}.Current`] = {
+            device_mode: 'switch',
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+                mqtt_publish_funct: value => JSON.parse(value).current,
+            },
+            common: {
+                name: 'Current',
+                type: 'number',
+                role: 'value.current',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'A',
+            },
+        };
+
+        deviceObj[`Relay${switchId}.Energy`] = {
+            device_mode: 'switch',
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+                mqtt_publish_funct: value => JSON.parse(value).aenergy.total,
+            },
+            common: {
+                name: 'Energy',
+                type: 'number',
+                role: 'value.power.consumption',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'Wh',
+            },
+        };
+
+        /*
+        deviceObj[`Relay${switchId}.Overvoltage`] = {
+            device_mode: 'switch',
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+                mqtt_publish_funct: value => {
+                    const valueObj = JSON.parse(value);
+                    return valueObj.errors && Array.prototype.includes.call(valueObj.errors, 'overvoltage');
+                },
+            },
+            common: {
+                name: 'Overvoltage',
+                type: 'boolean',
+                role: 'indicator.alarm',
+                read: true,
+                write: false,
+                def: false
+            }
+        };
+        */
+
+        deviceObj[`Relay${switchId}.LimitPower`] = {
+            device_mode: 'switch',
+            mqtt: {
+                http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+                http_publish_funct: value => value ? JSON.parse(value).power_limit : undefined,
+                mqtt_cmd: '<mqttprefix>/rpc',
+                mqtt_cmd_funct: (value, self) => {
+                    return JSON.stringify({
+                        id: self.getNextMsgId(),
+                        src: 'iobroker',
+                        method: 'Switch.SetConfig',
+                        params: { id: switchId, config: { power_limit: value } },
+                    });
+                },
+            },
+            common: {
+                name: 'Power Limit',
+                type: 'number',
+                role: 'value.power',
+                unit: 'W',
+                read: true,
+                write: true,
+            },
+        };
+
+        deviceObj[`Relay${switchId}.LimitCurrent`] = {
+            device_mode: 'switch',
+            mqtt: {
+                http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+                http_publish_funct: value => value ? JSON.parse(value).current_limit : undefined,
+                mqtt_cmd: '<mqttprefix>/rpc',
+                mqtt_cmd_funct: (value, self) => {
+                    return JSON.stringify({
+                        id: self.getNextMsgId(),
+                        src: 'iobroker',
+                        method: 'Switch.SetConfig',
+                        params: { id: switchId, config: { current_limit: value } },
+                    });
+                },
+            },
+            common: {
+                name: 'Current Limit',
+                type: 'number',
+                role: 'value.current',
+                unit: 'A',
+                read: true,
+                write: true,
+            },
+        };
+
+        deviceObj[`Relay${switchId}.LimitVoltage`] = {
+            device_mode: 'switch',
+            mqtt: {
+                http_publish: `/rpc/Switch.GetConfig?id=${switchId}`,
+                http_publish_funct: value => value ? JSON.parse(value).voltage_limit : undefined,
+                mqtt_cmd: '<mqttprefix>/rpc',
+                mqtt_cmd_funct: (value, self) => {
+                    return JSON.stringify({
+                        id: self.getNextMsgId(),
+                        src: 'iobroker',
+                        method: 'Switch.SetConfig',
+                        params: { id: switchId, config: { voltage_limit: value } },
+                    });
+                },
+            },
+            common: {
+                name: 'Voltage Limit',
+                type: 'number',
+                role: 'value.voltage',
+                unit: 'V',
+                read: true,
+                write: true,
+            },
+        };
+    }
+
+}
+
+/**
+ * Adds a generic input definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} inputId
+ */
+function addInputToGen3Device(deviceObj, inputId) {
+
+    deviceObj[`Input${inputId}.Status`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/input:${inputId}`,
+            mqtt_publish_funct: value => JSON.parse(value).state,
+        },
+        common: {
+            name: 'Input Status',
+            type: 'boolean',
+            role: 'state',
+            read: true,
+            write: false,
+        },
+    };
+
+    deviceObj[`Input${inputId}.ChannelName`] = {
+        mqtt: {
+            http_publish: `/rpc/Input.GetConfig?id=${inputId}`,
+            http_publish_funct: async (value, self) => {
+                return value ? await shellyHelper.setChannelName(self, `Input${inputId}`, JSON.parse(value).name) : undefined;
+            },
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Input.SetConfig',
+                    params: { id: inputId, config: { name: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Channel name',
+                de: 'Kanalname',
+                ru: 'Имя канала',
+                pt: 'Nome do canal',
+                nl: 'Kanaalnaam',
+                fr: 'Nom du canal',
+                it: 'Nome del canale',
+                es: 'Nombre del canal',
+                pl: 'Channel imię',
+                'zh-cn': '姓名',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: true,
+            def: `input_${inputId}`,
+        },
+    };
+
+    deviceObj[`Input${inputId}.Event`] = {
+        mqtt: {
+            mqtt_publish: '<mqttprefix>/events/rpc',
+            mqtt_publish_funct: value => {
+                const valueObj = JSON.parse(value);
+                if (valueObj?.method === 'NotifyEvent' && valueObj?.params?.events) {
+                    for (const e in valueObj.params.events) {
+                        const event = valueObj.params.events[e];
+
+                        if (typeof event === 'object' && event.component === `input:${inputId}`) {
+                            return event.event;
+                        }
+                    }
+                }
+                return undefined;
+            },
+        },
+        common: {
+            name: 'Input Event',
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: false,
+        },
+    };
+
+    deviceObj[`Input${inputId}.InputType`] = {
+        mqtt: {
+            http_publish: `/rpc/Input.GetConfig?id=${inputId}`,
+            http_publish_funct: value => value ? JSON.parse(value).type : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Input.SetConfig',
+                    params: { id: inputId, config: { type: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Input Type',
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: true,
+            states: {
+                'button': 'button',
+                'switch': 'switch',
+            },
+        },
+    };
+
+    deviceObj[`Input${inputId}.InputInverted`] = {
+        mqtt: {
+            http_publish: `/rpc/Input.GetConfig?id=${inputId}`,
+            http_publish_funct: value => value ? JSON.parse(value).invert : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Input.SetConfig',
+                    params: { id: inputId, config: { invert: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Input Inverted',
+            type: 'boolean',
+            role: 'state',
+            read: true,
+            write: true,
+        },
+    };
+
+}
+
+/**
+ * Adds a generic cover definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} coverId
+ */
+function addCoverToGen3Device(deviceObj, coverId) {
+
+    deviceObj[`Cover${coverId}.InitialState`] = {
+        device_mode: 'cover',
+        mqtt: {
+            http_publish: `/rpc/Cover.GetConfig?id=${coverId}`,
+            http_publish_funct: value => value ? JSON.parse(value).initial_state : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.SetConfig',
+                    params: { id: coverId, config: { initial_state: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Initial State',
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: true,
+            states: {
+                'open': 'oopenn',
+                'closed': 'closed',
+                'stopped': 'stopped',
+            },
+        },
+    };
+
+    deviceObj[`Cover${coverId}.ChannelName`] = {
+        device_mode: 'cover',
+        mqtt: {
+            http_publish: `/rpc/Cover.GetConfig?id=${coverId}`,
+            http_publish_funct: async (value, self) => {
+                return value ? await shellyHelper.setChannelName(self, `Cover${coverId}`, JSON.parse(value).name) : undefined;
+            },
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.SetConfig',
+                    params: { id: coverId, config: { name: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Channel name',
+                de: 'Kanalname',
+                ru: 'Имя канала',
+                pt: 'Nome do canal',
+                nl: 'Kanaalnaam',
+                fr: 'Nom du canal',
+                it: 'Nome del canale',
+                es: 'Nombre del canal',
+                pl: 'Channel imię',
+                'zh-cn': '姓名',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: true,
+            def: `cover_${coverId}`,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Duration`] = {
+        device_mode: 'cover',
+        mqtt: {
+            http_publish: `/rpc/Cover.GetConfig?id=${coverId}`,
+            http_publish_funct: async (value, self) => {
+                return await shellyHelper.getSetDuration(self, `Cover${coverId}.Duration`);
+            },
+        },
+        common: {
+            name: {
+                en: 'Duration',
+                de: 'Dauer',
+                ru: 'Продолжительность',
+                pt: 'Duração',
+                nl: 'Vertaling:',
+                fr: 'Durée',
+                it: 'Durata',
+                es: 'Duración',
+                pl: 'Duracja',
+                'zh-cn': '期间',
+            },
+            type: 'number',
+            role: 'level.timer',
+            read: true,
+            write: true,
+            def: 0,
+            unit: 's',
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Open`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: async (value, self) => {
+                const duration = await shellyHelper.getSetDuration(self, `Cover${coverId}.Duration`, 0);
+
+                if (duration > 0) {
+                    return JSON.stringify({
+                        id: self.getNextMsgId(),
+                        src: 'iobroker',
+                        method: 'Cover.Open',
+                        params: { id: coverId, duration: duration },
+                    });
+                } else {
+                    return JSON.stringify({
+                        id: self.getNextMsgId(),
+                        src: 'iobroker',
+                        method: 'Cover.Open',
+                        params: { id: coverId },
+                    });
+                }
+            },
+        },
+        common: {
+            name: 'Open',
+            type: 'boolean',
+            role: 'button',
+            read: false,
+            write: true,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Stop`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.Stop',
+                    params: { id: coverId },
+                });
+            },
+        },
+        common: {
+            name: 'Stop',
+            type: 'boolean',
+            role: 'button',
+            read: false,
+            write: true,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Close`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: async (value, self) => {
+                const duration = await shellyHelper.getSetDuration(self, `Cover${coverId}.Duration`, 0);
+
+                if (duration > 0) {
+                    return JSON.stringify({
+                        id: self.getNextMsgId(),
+                        src: 'iobroker',
+                        method: 'Cover.Close',
+                        params: { id: coverId, duration: duration },
+                    });
+                } else {
+                    return JSON.stringify({
+                        id: self.getNextMsgId(),
+                        src: 'iobroker',
+                        method: 'Cover.Close',
+                        params: { id: coverId },
+                    });
+                }
+            },
+        },
+        common: {
+            name: 'Close',
+            type: 'boolean',
+            role: 'button',
+            read: false,
+            write: true,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Calibrate`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.Calibrate',
+                    params: { id: coverId },
+                });
+            },
+        },
+        common: {
+            name: 'Calibrate',
+            type: 'boolean',
+            role: 'button',
+            read: false,
+            write: true,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.InputSwap`] = {
+        device_mode: 'cover',
+        mqtt: {
+            http_publish: `/rpc/Cover.GetConfig?id=${coverId}`,
+            http_publish_funct: value => value ? JSON.parse(value).swap_inputs : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.SetConfig',
+                    params: { id: coverId, config: { swap_inputs: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Input Swap',
+            type: 'boolean',
+            role: 'switch.enable',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.InputMode`] = {
+        device_mode: 'cover',
+        mqtt: {
+            http_publish: `/rpc/Cover.GetConfig?id=${coverId}`,
+            http_publish_funct: value => value ? JSON.parse(value).in_mode : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.SetConfig',
+                    params: { id: coverId, config: { in_mode: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Input Mode',
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: true,
+            states: {
+                'single': 'single',
+                'dual': 'dual',
+                'detached': 'detached',
+            },
+        },
+    };
+
+    deviceObj[`Cover${coverId}.LimitPower`] = {
+        device_mode: 'cover',
+        mqtt: {
+            http_publish: `/rpc/Cover.GetConfig?id=${coverId}`,
+            http_publish_funct: value => value ? JSON.parse(value).power_limit : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.SetConfig',
+                    params: { id: coverId, config: { power_limit: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Power Limit',
+            type: 'number',
+            role: 'value.power',
+            unit: 'W',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.LimitCurrent`] = {
+        device_mode: 'cover',
+        mqtt: {
+            http_publish: `/rpc/Cover.GetConfig?id=${coverId}`,
+            http_publish_funct: value => value ? JSON.parse(value).current_limit : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.SetConfig',
+                    params: { id: coverId, config: { current_limit: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Current Limit',
+            type: 'number',
+            role: 'value.current',
+            unit: 'A',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.LimitVoltage`] = {
+        device_mode: 'cover',
+        mqtt: {
+            http_publish: `/rpc/Cover.GetConfig?id=${coverId}`,
+            http_publish_funct: value => value ? JSON.parse(value).voltage_limit : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.SetConfig',
+                    params: { id: coverId, config: { voltage_limit: value } },
+                });
+            },
+        },
+        common: {
+            name: 'Voltage Limit',
+            type: 'number',
+            role: 'value.voltage',
+            unit: 'V',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Position`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).current_pos,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Cover.GoToPosition',
+                    params: { id: coverId, pos: value },
+                });
+            },
+        },
+        common: {
+            name: 'Position',
+            type: 'number',
+            role: 'level.blind',
+            read: true,
+            write: true,
+            def: 0,
+            unit: '%',
+            min: 0,
+            max: 100,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Status`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).state,
+        },
+        common: {
+            name: 'Cover Status',
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: false,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Power`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).apower,
+        },
+        common: {
+            name: 'Power',
+            type: 'number',
+            role: 'value.power',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'W',
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Voltage`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).voltage,
+        },
+        common: {
+            name: {
+                en: 'Voltage',
+                de: 'Spannung',
+                ru: 'Напряжение',
+                pt: 'Tensão',
+                nl: 'Voltage',
+                fr: 'Tension',
+                it: 'Tensione',
+                es: 'Voltaje',
+                pl: 'Voltage',
+                'zh-cn': '动产',
+            },
+            type: 'number',
+            role: 'value.voltage',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'V',
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Current`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).current,
+        },
+        common: {
+            name: 'Current',
+            type: 'number',
+            role: 'value.current',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'A',
+        },
+    };
+
+    deviceObj[`Cover${coverId}.Energy`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).aenergy.total,
+        },
+        common: {
+            name: 'Energy',
+            type: 'number',
+            role: 'value.power.consumption',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'Wh',
+        },
+    };
+
+    deviceObj[`Cover${coverId}.source`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).source,
+        },
+        common: {
+            name: {
+                en: 'Source of last command',
+                de: 'Quelle des letzten Befehls',
+                ru: 'Источник последней команды',
+                pt: 'Fonte do último comando',
+                nl: 'Vertaling:',
+                fr: 'Source de la dernière commande',
+                it: 'Fonte dell\'ultimo comando',
+                es: 'Fuente del último comando',
+                pl: 'Źródło ostatniego dowództwa',
+                'zh-cn': '最后一次指挥的来源',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: false,
+        },
+    };
+
+    deviceObj[`Cover${coverId}.temperatureC`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).temperature.tC,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°C',
+        },
+    };
+
+    deviceObj[`Cover${coverId}.temperatureF`] = {
+        device_mode: 'cover',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
+            mqtt_publish_funct: value => JSON.parse(value).temperature.tF,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°F',
+        },
+    };
+
+}
+
+/**
+ * Adds a generic power definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} devicePowerId
+ * @param {boolean} hasExternalPower
+ */
+function addDevicePowerToGen3Device(deviceObj, devicePowerId, hasExternalPower) {
+
+    deviceObj[`DevicePower${devicePowerId}.BatteryVoltage`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/devicepower:${devicePowerId}`,
+            mqtt_publish_funct: value => JSON.parse(value).battery.V,
+        },
+        common: {
+            name: {
+                en: 'Battery voltage',
+                de: 'Batteriespannung',
+                ru: 'Напряжение батареи',
+                pt: 'Tensão da bateria',
+                nl: 'Batterij voltage',
+                fr: 'Tension de la batterie',
+                it: 'Tensione della batteria',
+                es: 'Tensión de la batería',
+                pl: 'Napięcie',
+                'zh-cn': '電池電壓',
+            },
+            type: 'number',
+            role: 'value.voltage',
+            read: true,
+            write: false,
+            unit: 'V',
+        },
+    };
+
+    deviceObj[`DevicePower${devicePowerId}.BatteryPercent`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/devicepower:${devicePowerId}`,
+            mqtt_publish_funct: value => JSON.parse(value).battery.percent,
+        },
+        common: {
+            name: {
+                en: 'Battery charge level',
+                de: 'Batterieladestand',
+                ru: 'Уровень заряда батареи',
+                pt: 'Nível de carga da bateria',
+                nl: 'Batterij niveau',
+                fr: 'Niveau de charge de la batterie',
+                it: 'Livello di carica della batteria',
+                es: 'Nivel de carga de la batería',
+                pl: 'Poziom baterii',
+                'zh-cn': '包 费',
+            },
+            type: 'number',
+            role: 'value.battery',
+            read: true,
+            write: false,
+            unit: '%',
+            min: 0,
+            max: 100,
+        },
+    };
+
+    if (hasExternalPower) {
+        deviceObj[`DevicePower${devicePowerId}.ExternalPower`] = {
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/devicepower:${devicePowerId}`,
+                mqtt_publish_funct: value => JSON.parse(value).external.present,
+            },
+            common: {
+                name: {
+                    en: 'External power supply',
+                    de: 'Externe Stromversorgung',
+                    ru: 'Внешний источник питания',
+                    pt: 'Fonte de alimentação externa',
+                    nl: 'Vertaling:',
+                    fr: 'Alimentation extérieure',
+                    it: 'Alimentazione elettrica esterna',
+                    es: 'Fuente de alimentación externa',
+                    pl: 'Zasilanie zewnętrzne',
+                    'zh-cn': '外部电力供应',
+                },
+                type: 'boolean',
+                role: 'state',
+                read: true,
+                write: false,
+            },
+        };
+    }
+
+}
+
+/**
+ * Adds a generic temperature sensor definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} sensorId
+ */
+function addTemperatureSensorToGen3Device(deviceObj, sensorId) {
+
+    deviceObj[`Temperature${sensorId}.ChannelName`] = {
+        mqtt: {
+            http_publish: `/rpc/Temperature.GetConfig?id=${sensorId}`,
+            http_publish_funct: async (value, self) => {
+                return value ? await shellyHelper.setChannelName(self, `Temperature${sensorId}`, JSON.parse(value).name) : undefined;
+            },
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Temperature.SetConfig',
+                    params: { id: sensorId, config: { name: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Channel name',
+                de: 'Kanalname',
+                ru: 'Имя канала',
+                pt: 'Nome do canal',
+                nl: 'Kanaalnaam',
+                fr: 'Nom du canal',
+                it: 'Nome del canale',
+                es: 'Nombre del canal',
+                pl: 'Channel imię',
+                'zh-cn': '姓名',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Temperature${sensorId}.Celsius`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:${sensorId}`,
+            mqtt_publish_funct: value => JSON.parse(value).tC,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°C',
+        },
+    };
+
+    deviceObj[`Temperature${sensorId}.Fahrenheit`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:${sensorId}`,
+            mqtt_publish_funct: value => JSON.parse(value).tF,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°F',
+        },
+    };
+
+    deviceObj[`Temperature${sensorId}.ReportThreshold`] = {
+        mqtt: {
+            http_publish: `/rpc/Temperature.GetConfig?id=${sensorId}`,
+            http_publish_funct: value => value ? JSON.parse(value).report_thr_C : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Temperature.SetConfig',
+                    params: { id: sensorId, config: { report_thr_C: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Report threshold',
+                de: 'Meldeschwelle',
+                ru: 'Порог отчета',
+                pt: 'Limiar de referência',
+                nl: 'Vertaling:',
+                fr: 'Limite du rapport',
+                it: 'Soglia di relazione',
+                es: 'Nivel de informe',
+                pl: 'Raport o progu',
+                'zh-cn': '报告阈值',
+            },
+            type: 'number',
+            role: 'level.temperature',
+            read: true,
+            write: true,
+            unit: '°C',
+            def: 1,
+            min: 0.5,
+            max: 5,
+        },
+    };
+
+}
+
+/**
+ * Adds a generic humidity sensor definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} sensorId
+ */
+function addHumiditySensorToGen3Device(deviceObj, sensorId) {
+
+    deviceObj[`Humidity${sensorId}.ChannelName`] = {
+        mqtt: {
+            http_publish: `/rpc/Humidity.GetConfig?id=${sensorId}`,
+            http_publish_funct: async (value, self) => {
+                return value ? await shellyHelper.setChannelName(self, `Humidity${sensorId}`, JSON.parse(value).name) : undefined;
+            },
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Humidity.SetConfig',
+                    params: { id: sensorId, config: { name: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Channel name',
+                de: 'Kanalname',
+                ru: 'Имя канала',
+                pt: 'Nome do canal',
+                nl: 'Kanaalnaam',
+                fr: 'Nom du canal',
+                it: 'Nome del canale',
+                es: 'Nombre del canal',
+                pl: 'Channel imię',
+                'zh-cn': '姓名',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`Humidity${sensorId}.Relative`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/humidity:${sensorId}`,
+            mqtt_publish_funct: value => JSON.parse(value).rh,
+        },
+        common: {
+            name: {
+                en: 'Humidity',
+                de: 'Luftfeuchtigkeit',
+                ru: 'Влажность',
+                pt: 'Humidade',
+                nl: 'Humid',
+                fr: 'Humidité',
+                it: 'Umidità',
+                es: 'Humedad',
+                pl: 'Humity',
+                'zh-cn': '死 情',
+            },
+            type: 'number',
+            role: 'value.humidity',
+            read: true,
+            write: false,
+            unit: '%',
+        },
+    };
+
+    deviceObj[`Humidity${sensorId}.ReportThreshold`] = {
+        mqtt: {
+            http_publish: `/rpc/Humidity.GetConfig?id=${sensorId}`,
+            http_publish_funct: value => value ? JSON.parse(value).report_thr : undefined,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Humidity.SetConfig',
+                    params: { id: sensorId, config: { report_thr: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Report threshold',
+                de: 'Meldeschwelle',
+                ru: 'Порог отчета',
+                pt: 'Limiar de referência',
+                nl: 'Vertaling:',
+                fr: 'Limite du rapport',
+                it: 'Soglia di relazione',
+                es: 'Nivel de informe',
+                pl: 'Raport o progu',
+                'zh-cn': '报告阈值',
+            },
+            type: 'number',
+            role: 'level.humidity',
+            read: true,
+            write: true,
+            unit: '%',
+            def: 5,
+            min: 1,
+            max: 20,
+        },
+    };
+
+}
+
+/**
+ * Adds a generic energymeter definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} emId
+ * @param {array} phases
+ */
+function addEnergyMeterToGen3Device(deviceObj, emId, phases) {
+
+    deviceObj[`EM${emId}.ChannelName`] = {
+        mqtt: {
+            http_publish: `/rpc/EM.GetConfig?id=${emId}`,
+            http_publish_funct: async (value, self) => {
+                return value ? await shellyHelper.setChannelName(self, `EM${emId}`, JSON.parse(value).name) : undefined;
+            },
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'EM.SetConfig',
+                    params: { id: emId, config: { name: value } },
+                });
+            },
+        },
+        common: {
+            name: {
+                en: 'Channel name',
+                de: 'Kanalname',
+                ru: 'Имя канала',
+                pt: 'Nome do canal',
+                nl: 'Kanaalnaam',
+                fr: 'Nom du canal',
+                it: 'Nome del canale',
+                es: 'Nombre del canal',
+                pl: 'Channel imię',
+                'zh-cn': '姓名',
+            },
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: true,
+        },
+    };
+
+    deviceObj[`EM${emId}.CurrentN`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+            mqtt_publish_funct: value => {
+                return JSON.parse(value)[`n_current`];
+            },
+        },
+        common: {
+            name: 'Current N',
+            type: 'number',
+            role: 'value.current',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'A',
+        },
+    };
+
+    deviceObj[`EM${emId}.TotalCurrent`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+            mqtt_publish_funct: value => {
+                return JSON.parse(value)[`total_current`];
+            },
+        },
+        common: {
+            name: 'Total Current',
+            type: 'number',
+            role: 'value.current',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'A',
+        },
+    };
+
+    deviceObj[`EM${emId}.TotalActivePower`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+            mqtt_publish_funct: value => {
+                return JSON.parse(value)[`total_act_power`];
+            },
+        },
+        common: {
+            name: 'Total Power (active)',
+            type: 'number',
+            role: 'value.power',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'W',
+        },
+    };
+
+    deviceObj[`EM${emId}.TotalApparentPower`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+            mqtt_publish_funct: value => {
+                return JSON.parse(value)[`total_aprt_power`];
+            },
+        },
+        common: {
+            name: 'Total Power (apparent)',
+            type: 'number',
+            role: 'value.power',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'VA',
+        },
+    };
+
+    for (const phase of phases) {
+
+        const phaseUp = String(phase).toUpperCase();
+
+        deviceObj[`EM${emId}.Voltage${phaseUp}`] = {
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+                mqtt_publish_funct: value => {
+                    return JSON.parse(value)[`${phase}_voltage`];
+                },
+            },
+            common: {
+                name: {
+                    en: 'Voltage',
+                    de: 'Spannung',
+                    ru: 'Напряжение',
+                    pt: 'Tensão',
+                    nl: 'Voltage',
+                    fr: 'Tension',
+                    it: 'Tensione',
+                    es: 'Voltaje',
+                    pl: 'Voltage',
+                    'zh-cn': '动产',
+                },
+                type: 'number',
+                role: 'value.voltage',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'V',
+            },
+        };
+
+        deviceObj[`EM${emId}.Current${phaseUp}`] = {
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+                mqtt_publish_funct: value => {
+                    return JSON.parse(value)[`${phase}_current`];
+                },
+            },
+            common: {
+                name: 'Current',
+                type: 'number',
+                role: 'value.current',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'A',
+            },
+        };
+
+        deviceObj[`EM${emId}.ActivePower${phaseUp}`] = {
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+                mqtt_publish_funct: value => {
+                    return JSON.parse(value)[`${phase}_act_power`];
+                },
+            },
+            common: {
+                name: 'Power (active)',
+                type: 'number',
+                role: 'value.power',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'W',
+            },
+        };
+
+        deviceObj[`EM${emId}.ApparentPower${phaseUp}`] = {
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+                mqtt_publish_funct: value => {
+                    return JSON.parse(value)[`${phase}_aprt_power`];
+                },
+            },
+            common: {
+                name: 'Power (apparent)',
+                type: 'number',
+                role: 'value.power',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'VA',
+            },
+        };
+
+        deviceObj[`EM${emId}.PowerFactor${phaseUp}`] = {
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/em:${emId}`,
+                mqtt_publish_funct: value => {
+                    return JSON.parse(value)[`${phase}_pf`];
+                },
+            },
+            common: {
+                name: 'Power Factor',
+                type: 'number',
+                role: 'value',
+                read: true,
+                write: false,
+                def: 0,
+            },
+        };
+
+    }
+}
+
+/**
+ * Adds a generic energymeter data definition for gen 3 devices
+ * @param {object} deviceObj
+ * @param {number} emId
+ * @param {array} phases
+ */
+function addEnergyMeterDataToGen3Device(deviceObj, emId, phases) {
+
+    deviceObj[`EMData${emId}.TotalActiveEnergy`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/emdata:${emId}`,
+            mqtt_publish_funct: value => {
+                return JSON.parse(value)[`total_act`];
+            },
+        },
+        common: {
+            name: 'Total Energy (active)',
+            type: 'number',
+            role: 'value.power.consumption',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'Wh',
+        },
+    };
+
+    deviceObj[`EMData${emId}.TotalActiveReturnEnergy`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/emdata:${emId}`,
+            mqtt_publish_funct: value => {
+                return JSON.parse(value)[`total_act_ret`];
+            },
+        },
+        common: {
+            name: 'Total Return Energy (active)',
+            type: 'number',
+            role: 'value.power.consumption',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'Wh',
+        },
+    };
+
+    for (const phase of phases) {
+
+        const phaseUp = String(phase).toUpperCase();
+
+        deviceObj[`EMData${emId}.TotalActiveEnergy${phaseUp}`] = {
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/emdata:${emId}`,
+                mqtt_publish_funct: value => {
+                    return JSON.parse(value)[`${phase}_total_act_energy`];
+                },
+            },
+            common: {
+                name: 'Energy (active)',
+                type: 'number',
+                role: 'value.power.consumption',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'Wh',
+            },
+        };
+
+        deviceObj[`EMData${emId}.TotalActiveReturnEnergy${phaseUp}`] = {
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/emdata:${emId}`,
+                mqtt_publish_funct: value => {
+                    return JSON.parse(value)[`${phase}_total_act_ret_energy`];
+                },
+            },
+            common: {
+                name: 'Return Energy (active)',
+                type: 'number',
+                role: 'value.power.consumption',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'Wh',
+            },
+        };
+
+    }
+}
+
+/**
+ * Adds states for the Shelly Plus AddOn
+ * @param {object} deviceObj
+ */
+function addPlusAddon(deviceObj) {
+
+    deviceObj['Ext.input100'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/input:100`,
+            mqtt_publish_funct: value => JSON.parse(value).state,
+        },
+        common: {
+            name: 'Input100',
+            type: 'boolean',
+            role: 'state',
+            read: true,
+            write: false,
+            def: false,
+        },
+    };
+
+    deviceObj['Ext.input101'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/input:101`,
+            mqtt_publish_funct: value => JSON.parse(value).percent,
+        },
+        common: {
+            name: 'Input101',
+            type: 'number',
+            role: 'value',
+            read: true,
+            write: false,
+            unit: '%',
+            def: 0,
+        },
+    };
+
+    deviceObj['Ext.voltmeter100'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/voltmeter:100`,
+            mqtt_publish_funct: value => JSON.parse(value).voltage,
+        },
+        common: {
+            name: 'Volmeter100',
+            type: 'number',
+            role: 'value.voltage',
+            read: true,
+            write: false,
+            unit: 'V',
+            def: 0,
+        },
+    };
+
+    deviceObj['Ext.temperature100C'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:100`,
+            mqtt_publish_funct: value => JSON.parse(value).tC,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°C',
+        },
+    };
+
+    deviceObj['Ext.temperature100F'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:100`,
+            mqtt_publish_funct: value => JSON.parse(value).tF,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°F',
+        },
+    };
+
+    deviceObj['Ext.temperature101C'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:101`,
+            mqtt_publish_funct: value => JSON.parse(value).tC,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°C',
+        },
+    };
+
+    deviceObj['Ext.temperature101F'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:101`,
+            mqtt_publish_funct: value => JSON.parse(value).tF,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°F',
+        },
+    };
+
+    deviceObj['Ext.temperature102C'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:102`,
+            mqtt_publish_funct: value => JSON.parse(value).tC,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°C',
+        },
+    };
+
+    deviceObj['Ext.temperature102F'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:102`,
+            mqtt_publish_funct: value => JSON.parse(value).tF,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°F',
+        },
+    };
+
+    deviceObj['Ext.temperature103C'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:103`,
+            mqtt_publish_funct: value => JSON.parse(value).tC,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°C',
+        },
+    };
+
+    deviceObj['Ext.temperature103F'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:103`,
+            mqtt_publish_funct: value => JSON.parse(value).tF,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°F',
+        },
+    };
+
+    deviceObj['Ext.temperature104C'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:104`,
+            mqtt_publish_funct: value => JSON.parse(value).tC,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°C',
+        },
+    };
+
+    deviceObj['Ext.temperature104F'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/temperature:104`,
+            mqtt_publish_funct: value => JSON.parse(value).tF,
+        },
+        common: {
+            name: {
+                en: 'Temperature',
+                de: 'Temperatur',
+                ru: 'Температура',
+                pt: 'Temperatura',
+                nl: 'Temperatuur',
+                fr: 'Température',
+                it: 'Temperatura',
+                es: 'Temperatura',
+                pl: 'Temperatura',
+                'zh-cn': '模范',
+            },
+            type: 'number',
+            role: 'value.temperature',
+            read: true,
+            write: false,
+            unit: '°F',
+        },
+    };
+
+    deviceObj['Ext.humidity100'] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/humidity:100`,
+            mqtt_publish_funct: value => JSON.parse(value).rh,
+        },
+        common: {
+            name: {
+                en: 'Humidity',
+                de: 'Luftfeuchtigkeit',
+                ru: 'Влажность',
+                pt: 'Humidade',
+                nl: 'Humid',
+                fr: 'Humidité',
+                it: 'Umidità',
+                es: 'Humedad',
+                pl: 'Humity',
+                'zh-cn': '死 情',
+            },
+            type: 'number',
+            role: 'value.humidity',
+            read: true,
+            write: false,
+            unit: '%',
+        },
+    };
+}
+
+module.exports = {
+    addSwitchToGen3Device,
+    addInputToGen3Device,
+    addCoverToGen3Device,
+    addDevicePowerToGen3Device,
+    addTemperatureSensorToGen3Device,
+    addHumiditySensorToGen3Device,
+    addEnergyMeterToGen3Device,
+    addEnergyMeterDataToGen3Device,
+    addPM1ToGen3Device,
+    addPlusAddon,
+    addIlluminanceSensorToGen3Device,
+};

--- a/lib/devices/gen3/shelly1pmminig3.js
+++ b/lib/devices/gen3/shelly1pmminig3.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const shellyHelperGen3 = require('../gen3-helper');
+
+/**
+ * Shelly 1 PM Mini (Gen 3) / shellyplus1pmmini
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/ShellyMini1PMG3/
+ */
+const shelly1pmminig3 = {
+
+};
+
+shellyHelperGen3.addSwitchToGen2Device(shelly1pmminig3, 0, true);
+
+shellyHelperGen3.addInputToGen2Device(shelly1pmminig3, 0);
+
+module.exports = {
+    sshelly1pmminig3,
+};

--- a/lib/devices/gen3/shelly1pmminig3.js
+++ b/lib/devices/gen3/shelly1pmminig3.js
@@ -1,20 +1,18 @@
-'use strict';
+"use strict";
 
-const shellyHelperGen3 = require('../gen3-helper');
+const shellyHelperGen3 = require("../gen3-helper");
 
 /**
  * Shelly 1 PM Mini (Gen 3) / shellyplus1pmmini
  *
  * https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/ShellyMini1PMG3/
  */
-const shelly1pmminig3 = {
+const shelly1pmminig3 = {};
 
-};
+shellyHelperGen3.addSwitchToGen3Device(shelly1pmminig3, 0, true);
 
-shellyHelperGen3.addSwitchToGen2Device(shelly1pmminig3, 0, true);
-
-shellyHelperGen3.addInputToGen2Device(shelly1pmminig3, 0);
+shellyHelperGen3.addInputToGen3Device(shelly1pmminig3, 0);
 
 module.exports = {
-    sshelly1pmminig3,
+  shelly1pmminig3,
 };

--- a/lib/devices/gen3/shellymini1g3.js
+++ b/lib/devices/gen3/shellymini1g3.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const shellyHelperGen3 = require('../gen3-helper');
+
+/**
+ * Shelly 1 Mini (Gen 3) / shelly1mini1g3
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/ShellyMini1G3
+ */
+const shelly1mini = {
+
+};
+
+shellyHelperGen3.addSwitchToGen3Device(shellymini1g3, 0, false);
+
+shellyHelperGen3.addInputToGen3Device(shellymini1g3, 0);
+
+module.exports = {
+    shelly1mini1g3,
+};

--- a/lib/devices/gen3/shellymini1g3.js
+++ b/lib/devices/gen3/shellymini1g3.js
@@ -1,20 +1,18 @@
-'use strict';
+"use strict";
 
-const shellyHelperGen3 = require('../gen3-helper');
+const shellyHelperGen3 = require("../gen3-helper");
 
 /**
  * Shelly 1 Mini (Gen 3) / shelly1mini1g3
  *
  * https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/ShellyMini1G3
  */
-const shelly1mini = {
+const shelly1mini1g3 = {};
 
-};
+shellyHelperGen3.addSwitchToGen3Device(shelly1mini1g3, 0, false);
 
-shellyHelperGen3.addSwitchToGen3Device(shellymini1g3, 0, false);
-
-shellyHelperGen3.addInputToGen3Device(shellymini1g3, 0);
+shellyHelperGen3.addInputToGen3Device(shelly1mini1g3, 0);
 
 module.exports = {
-    shelly1mini1g3,
+  shelly1mini1g3,
 };


### PR DESCRIPTION
Hi @klein0r,
I added gen3 Devices (1 mini and 1PM mini).
I've asked the shelly devs and they told me that API and mqtt wise the gen2 and gen3 are currently the same - the only difference is the faster processor and more memory that enables them to introduce Matter and IPv6 :)

I copied the 1 and 1PM mini from gen2, created the gen3 category, and altered the needed if else if else statements to include gen3. Can you (or anyone smarter than me with my beginner js skills) please verify I did not miss anything? 
I hope this supports the development and gives you more time to focus on core problems :)