### PR TITLE
Added Shelly 1 Gen3 and 1PM Gen3 (regular size, not mini)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,6 @@ execute
 -->
 ### **WORK IN PROGRESS**
 
-* (imperial929) Added Shelly Plus RGBW PM
-* (imperial929) Added Shelly i4 Gen3
-* (imperial929) Added Shelly Dimmer Gen3
 * (imperial929) Added Shelly 1 PM Gen3
 * (imperial929) Added Shelly 1 Gen3
 * (klein0r) Breaking change: Renamed input states (now digital/analog) of Shelly Plus Addon (Ext)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ It uses the default Shelly firmware (no flashing of firmware needed!). You will 
 | Shelly 1 PM Mini Gen3 (shelly1pmminig3)   | ❌   | >= v7.0.0 | 20240425-141355/1.3.0-ga3fdd3d  |
 | Shelly PM Mini Gen3 (shellypmminig3)      | ❌   | >= v7.0.0 | 20240425-141418/1.3.0-ga3fdd3d  |
 | Shelly H&T Gen3 (shellyhtg3)              | ❌   | >= v7.1.0 | 20240425-141355/1.3.0-ga3fdd3d  |
+| Shelly 1 PM Gen3 (shelly1pmg3)            | ❌   | >= v7.1.0 | 20240425-141355/1.3.0-ga3fdd3d  |
+| Shelly 1 Gen3 (shelly1g3)                 | ❌   | >= v7.1.0 | 20240425-141355/1.3.0-ga3fdd3d  |
 
 ### Bluetooth Low Energy (BLU)
 
@@ -126,6 +128,9 @@ Adapter version >= v6.8.0 required!
 - Shelly Plus Plug US
 - Shelly Pro EM 2x50A
 - USB powered UVC LED strip
+- Shelly Plus RGBW PM (shellyplusrgbwpm)
+- Shelly i4 Gen3 (shellyi4g3)
+- Shelly Dimmer Gen3 (shelly0110dimg3)
 
 ## Sentry
 
@@ -147,6 +152,11 @@ execute
 -->
 ### **WORK IN PROGRESS**
 
+* (imperial929) Added Shelly Plus RGBW PM
+* (imperial929) Added Shelly i4 Gen3
+* (imperial929) Added Shelly Dimmer Gen3
+* (imperial929) Added Shelly 1 PM Gen3
+* (imperial929) Added Shelly 1 Gen3
 * (klein0r) Breaking change: Renamed input states (now digital/analog) of Shelly Plus Addon (Ext)
 * (klein0r) Added Shelly Plus Uni
 * (klein0r) Added Shelly H&T (Gen3)

--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -69,6 +69,9 @@ const shelly1minig3 = require('./devices/gen3/shelly1minig3').shelly1minig3;
 const shelly1pmminig3 = require('./devices/gen3/shelly1pmminig3').shelly1pmminig3;
 const shellypmminig3 = require('./devices/gen3/shellypmminig3').shellypmminig3;
 const shellyhtg3 = require('./devices/gen3/shellyhtg3').shellyhtg3;
+const shelly1pmg3 = require('./devices/gen3/shelly1pmg3').shelly1pmg3;
+const shelly1g3 = require('./devices/gen3/shelly1g3').shelly1g3;
+
 
 const devices = {
     // Gen 1
@@ -133,6 +136,8 @@ const devices = {
     shelly1pmminig3,
     shellypmminig3,
     shellyhtg3,
+    shelly1pmg3,
+    shelly1g3,
 };
 
 const deviceTypes = {
@@ -199,6 +204,8 @@ const deviceTypes = {
     shelly1pmminig3: ['shelly1pmminig3'],
     shellypmminig3: ['shellypmminig3'],
     shellyhtg3: ['shellyhtg3'],
+    shelly1pmg3: ['shelly1pmg3'],
+    shelly1g3: ['shelly1g3'],
 };
 
 const deviceGen = {
@@ -264,6 +271,8 @@ const deviceGen = {
     shelly1pmminig3: 3,
     shellypmminig3: 3,
     shellyhtg3: 3,
+    shelly1pmg3: 3,
+    shelly1g3: 3,
 };
 
 // https://shelly.cloud/knowledge-base/devices/
@@ -330,6 +339,8 @@ const deviceKnowledgeBase = {
     shelly1pmminig3: 'https://kb.shelly.cloud/knowledge-base/shelly-1pm-mini-gen3',
     shellypmminig3: 'https://kb.shelly.cloud/knowledge-base/shelly-pm-mini-gen3',
     shellyhtg3: 'https://kb.shelly.cloud/knowledge-base/shelly-h-t-gen3',
+    shelly1pmg3: 'https://kb.shelly.cloud/knowledge-base/shelly-1pm-gen3',
+    shelly1g3: 'https://kb.shelly.cloud/knowledge-base/shelly-1-gen3',
 };
 
 /**

--- a/lib/devices/gen3/shelly1g3.js
+++ b/lib/devices/gen3/shelly1g3.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const shellyHelperGen2 = require('../gen2-helper');
+
+/**
+ * Shelly 1 Gen 3 / shelly1g3
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/Shelly1G3
+ */
+const shelly1g3 = {};
+
+shellyHelperGen2.addSwitch(shelly1g3, 0, false);
+
+shellyHelperGen2.addInput(shelly1g3, 0);
+
+module.exports = {
+    shelly1minig3: shelly1g3,
+};

--- a/lib/devices/gen3/shelly1pmg3.js
+++ b/lib/devices/gen3/shelly1pmg3.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const shellyHelperGen2 = require('../gen2-helper');
+
+/**
+ * Shelly 1 PM Gen 3 / shelly1pmg3
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/Shelly1PMG3
+ */
+const shelly1pmg3 = {};
+
+shellyHelperGen2.addSwitch(shelly1pmg3, 0, true);
+
+shellyHelperGen2.addInput(shelly1pmg3, 0);
+
+module.exports = {
+    shelly1pmminig3: shelly1pmg3,
+};


### PR DESCRIPTION
Added the new 1 Gen3 and 1 PM Gen3.

RGBW PM Plus, Dimmer0-10 Gen3, and i4 Gen3 are still missing, but I already added the device-ID's to README for integration later)