### PR TITLE
Add addPlusAddon to shellyplusuni

### DIFF
--- a/lib/devices/gen2/shellyplusuni.js
+++ b/lib/devices/gen2/shellyplusuni.js
@@ -16,6 +16,8 @@ shellyHelperGen2.addInput(shellyplusuni, 2);
 shellyHelperGen2.addSwitch(shellyplusuni, 0, false);
 shellyHelperGen2.addSwitch(shellyplusuni, 1, false);
 
+shellyHelperGen2.addPlusAddon(shellyplusuni);
+
 module.exports = {
     shellyplusuni,
 };


### PR DESCRIPTION
Hier ein möglicher Fix für #1073

Der Shelly PlusUni untestützt Peripherals auf die gleiche Artundweise wie Shelly plus1pm.


![image](https://github.com/user-attachments/assets/d0d25f25-7c5c-4034-b355-61b4b19a4f4f)

Durch Aufruf von `addPlusAddon` werden die Objekte unter "ext" angelegt.  
Messweret des konfigurierten Eingangs (Voltmeter) werden im Iobroker angezeigt.

![image](https://github.com/user-attachments/assets/9cd8ee00-a6d3-4b20-82db-11e296a8cfb6)

