### PR TITLE
added handling of Total Active Energy data to addEM1 function for shellyproem50

### DIFF
--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -115,7 +115,8 @@ function addEM1(deviceObj, switchId) {
             unit: 'Hz',
         },
     };
-deviceObj[`EM1:${switchId}.TotalEnergy`] = {
+    
+    deviceObj[`EM1:${switchId}.TotalEnergy`] = {
         device_mode: 'em1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/em1data:${switchId}`,

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -124,7 +124,7 @@ deviceObj[`EM1:${switchId}.TotalEnergy`] = {
         common: {
             name: 'Total Energy',
             type: 'number',
-            role: 'value.total_energy',
+            role: 'value.energy',
             read: true,
             write: false,
             def: 0,

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -115,6 +115,22 @@ function addEM1(deviceObj, switchId) {
             unit: 'Hz',
         },
     };
+deviceObj[`EM1:${switchId}.TotalEnergy`] = {
+        device_mode: 'em1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/em1data:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).total_act_energy,
+        },
+        common: {
+            name: 'Total Energy',
+            type: 'number',
+            role: 'value.total_energy',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'Wh',
+        },
+    };
 }
 
 /**


### PR DESCRIPTION
This Change adds support for handling total active energy of the shellyproem50. Until this change the Energy Meter Data sent by this device where ignored and no Datapoint where created or updated as described in issue #1070 which should be solved with this code. I was able to prove this in my local installation.

While the addEM1 function was only used by the gen2/shellyproem50.js -device I added the handler just there.

![grafik](https://github.com/user-attachments/assets/c409e5b7-3d7c-4d5e-b3e4-0f48864995b7)

I would be happy if you would integrate this code to the main-project.

While this is my first pull request I ever sent, I'm not sure, if I did anything what should be done. So, feedback is welcome.

Regards
tclas 