### PR TITLE
Add missing states for pmminig3

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Adapter version >= v8.2.0 required for:
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+* (@mcm1957) Missing energy values for pmminigen3 have been added
+
 ### 9.2.0 (2025-03-13)
 
 * (@fLaSk1n) Added Shelly Dimmer Gen3

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -382,7 +382,7 @@ function addPM1(deviceObj, switchId) {
         common: {
             name: {
                     "en": "Returned Energy",
-                    "de": "Zurückgeführte Energie",
+                    "de": "Zurückgelieferte Energie",
                     "ru": "Возвращенная энергия",
                     "pt": "Energia Retornada",
                     "nl": "Teruggegeven energie",

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -238,17 +238,17 @@ function addPM1(deviceObj, switchId) {
         },
         common: {
             name: {
-                "en": "Apparent Power",
-                "de": "Scheinleistung",
-                "ru": "Кажущаяся мощность",
-                "pt": "Poder Aparente",
-                "nl": "Schijnbare kracht",
-                "fr": "Puissance apparente",
-                "it": "Potenza apparente",
-                "es": "Potencia aparente",
-                "pl": "Moc pozorna",
-                "uk": "Видима потужність",
-                "zh-cn": "视在功率"
+                en: 'Apparent Power',
+                de: 'Scheinleistung',
+                ru: 'Кажущаяся мощность',
+                pt: 'Poder Aparente',
+                nl: 'Schijnbare kracht',
+                fr: 'Puissance apparente',
+                it: 'Potenza apparente',
+                es: 'Potencia aparente',
+                pl: 'Moc pozorna',
+                uk: 'Видима потужність',
+                'zh-cn': '视在功率',
             },
             type: 'number',
             role: 'value.power',
@@ -259,7 +259,7 @@ function addPM1(deviceObj, switchId) {
         },
     };
 
-    deviceObj[`PM1:${switchId}.pf`]  = {
+    deviceObj[`PM1:${switchId}.pf`] = {
         device_mode: 'pm1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
@@ -286,7 +286,7 @@ function addPM1(deviceObj, switchId) {
             def: 0,
         },
     };
-    
+
     deviceObj[`PM1:${switchId}.Voltage`] = {
         device_mode: 'pm1',
         mqtt: {
@@ -381,18 +381,18 @@ function addPM1(deviceObj, switchId) {
         },
         common: {
             name: {
-                    "en": "Returned Energy",
-                    "de": "Zurückgelieferte Energie",
-                    "ru": "Возвращенная энергия",
-                    "pt": "Energia Retornada",
-                    "nl": "Teruggegeven energie",
-                    "fr": "Énergie restituée",
-                    "it": "Energia restituita",
-                    "es": "Energía devuelta",
-                    "pl": "Zwrócona energia",
-                    "uk": "Повернена енергія",
-                    "zh-cn": "回馈能量"
-                },
+                en: 'Returned Energy',
+                de: 'Zurückgelieferte Energie',
+                ru: 'Возвращенная энергия',
+                pt: 'Energia Retornada',
+                nl: 'Teruggegeven energie',
+                fr: 'Énergie restituée',
+                it: 'Energia restituita',
+                es: 'Energía devuelta',
+                pl: 'Zwrócona energia',
+                uk: 'Повернена енергія',
+                'zh-cn': '回馈能量',
+            },
             type: 'number',
             role: 'value.energy.produced',
             read: true,

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -195,7 +195,7 @@ function addEM1(deviceObj, switchId) {
 }
 
 /**
- * Adds a generic switch definition for Gen 2+ devices
+ * Adds a generic PM definition for Gen 2+ devices
  *
  * @param deviceObj
  * @param switchId
@@ -230,6 +230,63 @@ function addPM1(deviceObj, switchId) {
         },
     };
 
+    deviceObj[`PM1:${switchId}.aprtPower`] = {
+        device_mode: 'pm1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).aprtpower,
+        },
+        common: {
+            name: {
+                "en": "Apparent Power",
+                "de": "Scheinleistung",
+                "ru": "Кажущаяся мощность",
+                "pt": "Poder Aparente",
+                "nl": "Schijnbare kracht",
+                "fr": "Puissance apparente",
+                "it": "Potenza apparente",
+                "es": "Potencia aparente",
+                "pl": "Moc pozorna",
+                "uk": "Видима потужність",
+                "zh-cn": "视在功率"
+            },
+            type: 'number',
+            role: 'value.power',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'VA',
+        },
+    };
+
+    deviceObj[`PM1:${switchId}.pf`]  = {
+        device_mode: 'pm1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).pf,
+        },
+        common: {
+            name: {
+                en: 'Power Factor',
+                de: 'Leistungsfaktor',
+                ru: 'Коэффициент мощности',
+                pt: 'Fator de potência',
+                nl: 'Vermogensfactor',
+                fr: 'Facteur de puissance',
+                it: 'Fattore di potenza',
+                es: 'Factor de potencia',
+                pl: 'Współczynnik mocy',
+                uk: 'Фактор потужності',
+                'zh-cn': '功率因数',
+            },
+            type: 'number',
+            role: 'value',
+            read: true,
+            write: false,
+            def: 0,
+        },
+    };
+    
     deviceObj[`PM1:${switchId}.Voltage`] = {
         device_mode: 'pm1',
         mqtt: {
@@ -308,7 +365,36 @@ function addPM1(deviceObj, switchId) {
                 'zh-cn': '活力',
             },
             type: 'number',
-            role: 'value.energy',
+            role: 'value.energy.consumed',
+            read: true,
+            write: false,
+            def: 0,
+            unit: 'Wh',
+        },
+    };
+
+    deviceObj[`PM1:${switchId}.retEnergy`] = {
+        device_mode: 'pm1',
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
+            mqtt_publish_funct: value => JSON.parse(value).ret_aenergy.total,
+        },
+        common: {
+            name: {
+                    "en": "Returned Energy",
+                    "de": "Zurückgeführte Energie",
+                    "ru": "Возвращенная энергия",
+                    "pt": "Energia Retornada",
+                    "nl": "Teruggegeven energie",
+                    "fr": "Énergie restituée",
+                    "it": "Energia restituita",
+                    "es": "Energía devuelta",
+                    "pl": "Zwrócona energia",
+                    "uk": "Повернена енергія",
+                    "zh-cn": "回馈能量"
+                },
+            type: 'number',
+            role: 'value.energy.produced',
             read: true,
             write: false,
             def: 0,


### PR DESCRIPTION
This PR adds missing states to block PM1 used by pmminig3 as documents by shelly at https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/PM1

- aprtpower (Aparent Power)
- pf (Power Factor)
- retEnergy (Returned Energy)

