### PR TITLE
Add missing energy values to block switch (#1147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Adapter version >= v8.2.0 required for:
 ### **WORK IN PROGRESS**
 
 * (@mcm1957) Added Shelly Outdoor Plug S Gen3
+* (@mcm1957) Missing energy values for Swicthes (i.e. Shelly Outdoor Plug S Gen3) have been added
 * (@mcm1957) Missing energy values for pmminigen3 have been added
 
 ### 9.2.0 (2025-03-13)

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -419,6 +419,7 @@ function addPM1(deviceObj, switchId) {
         },
     };
 }
+
 /**
  * Adds a generic Illuminance sensor definition for Gen 2+ devices
  *
@@ -973,6 +974,63 @@ function addSwitch(deviceObj, switchId, hasPowerMetering) {
             },
         };
 
+        deviceObj[`Relay${switchId}.pf`] = {
+            device_mode: 'switch',
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+                mqtt_publish_funct: value => JSON.parse(value).pf,
+            },
+            common: {
+                name: {
+                    en: 'Power Factor',
+                    de: 'Leistungsfaktor',
+                    ru: 'Коэффициент мощности',
+                    pt: 'Fator de potência',
+                    nl: 'Vermogensfactor',
+                    fr: 'Facteur de puissance',
+                    it: 'Fattore di potenza',
+                    es: 'Factor de potencia',
+                    pl: 'Współczynnik mocy',
+                    uk: 'Фактор потужності',
+                    'zh-cn': '功率因数',
+                },
+                type: 'number',
+                role: 'value',
+                read: true,
+                write: false,
+                def: 0,
+            },
+        };
+
+        deviceObj[`Relay${switchId}.Frequency`] = {
+            device_mode: 'switch',
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+                mqtt_publish_funct: value => JSON.parse(value).freq,
+            },
+            common: {
+                name: {
+                    en: 'Frequency',
+                    de: 'Frequenz',
+                    ru: 'Частота',
+                    pt: 'Freqüência',
+                    nl: 'Frequentie',
+                    fr: 'Fréquence',
+                    it: 'Frequenza',
+                    es: 'Frecuencia',
+                    pl: 'Częstotliwość',
+                    uk: 'Частота',
+                    'zh-cn': '频率',
+                },
+                type: 'number',
+                role: 'value.frequency',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'Hz',
+            },
+        };
+
         deviceObj[`Relay${switchId}.Energy`] = {
             device_mode: 'switch',
             mqtt: {
@@ -994,7 +1052,36 @@ function addSwitch(deviceObj, switchId, hasPowerMetering) {
                     'zh-cn': '活力',
                 },
                 type: 'number',
-                role: 'value.energy',
+                role: 'value.energy.consumed',
+                read: true,
+                write: false,
+                def: 0,
+                unit: 'Wh',
+            },
+        };
+
+        deviceObj[`Relay${switchId}.retEnergy`] = {
+            device_mode: 'switch',
+            mqtt: {
+                mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
+                mqtt_publish_funct: value => JSON.parse(value).ret_aenergy.total,
+            },
+            common: {
+                name: {
+                    en: 'Returned Energy',
+                    de: 'Zurückgelieferte Energie',
+                    ru: 'Возвращенная энергия',
+                    pt: 'Energia Retornada',
+                    nl: 'Teruggegeven energie',
+                    fr: 'Énergie restituée',
+                    it: 'Energia restituita',
+                    es: 'Energía devuelta',
+                    pl: 'Zwrócona energia',
+                    uk: 'Повернена енергія',
+                    'zh-cn': '回馈能量',
+                },
+                type: 'number',
+                role: 'value.energy.produced',
                 read: true,
                 write: false,
                 def: 0,

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -259,7 +259,7 @@ function addPM1(deviceObj, switchId) {
         },
     };
 
-    deviceObj[`PM1:${switchId}.pf`] = {
+    deviceObj[`PM1:${switchId}.PowerFactor`] = {
         device_mode: 'pm1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
@@ -373,7 +373,7 @@ function addPM1(deviceObj, switchId) {
         },
     };
 
-    deviceObj[`PM1:${switchId}.retEnergy`] = {
+    deviceObj[`PM1:${switchId}.ReturnedEnergy`] = {
         device_mode: 'pm1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
@@ -974,7 +974,7 @@ function addSwitch(deviceObj, switchId, hasPowerMetering) {
             },
         };
 
-        deviceObj[`Relay${switchId}.pf`] = {
+        deviceObj[`Relay${switchId}.PowerFactor`] = {
             device_mode: 'switch',
             mqtt: {
                 mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
@@ -1060,7 +1060,7 @@ function addSwitch(deviceObj, switchId, hasPowerMetering) {
             },
         };
 
-        deviceObj[`Relay${switchId}.retEnergy`] = {
+        deviceObj[`Relay${switchId}.ReturnedEnergy`] = {
             device_mode: 'switch',
             mqtt: {
                 mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -230,7 +230,7 @@ function addPM1(deviceObj, switchId) {
         },
     };
 
-    deviceObj[`PM1:${switchId}.aprtPower`] = {
+    deviceObj[`PM1:${switchId}.ApparentPower`] = {
         device_mode: 'pm1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,


### PR DESCRIPTION
closes #1147 

SWITCH block defined attributes for ret_aenergy, pf and freq for shellies providing power measurement. (https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Switch).

Those attributes have been added to gen2 help "addSwitch"

In addition some just created state names have been adjusted to usual format

retEnerger -> ReturnedEnergy
pf -> PowerFactor
aprtPower -> ApparentPower