### PR TITLE
remove Shelly 3EM-63 Gen3 from unsupported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ Adapter version >= v8.2.0 required for:
 - USB powered UVC LED strip
 - Shelly DALI Dimmer Gen3
 - Shelly Wall Display X2
-- Shelly 3EM-63 Gen3
 - Shelly Pro RGBWW PM
 - Shelly 1L Gen3
 - Shelly 2L Gen3


### PR DESCRIPTION
Shelly 3EM-63 Gen3 has been added with 9.2.0. So it should no longer be liested as unsupported.

![image](https://github.com/user-attachments/assets/3ff850d2-659b-4403-a56e-efdce3a3ba81)

