### PR TITLE
Improved handling of optional attributes 

### DIFF
--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -377,7 +377,7 @@ function addPM1(deviceObj, switchId) {
         device_mode: 'pm1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
-            mqtt_publish_funct: value => JSON.parse(value).ret_xenergy.total,
+            mqtt_publish_funct: value => JSON.parse(value).ret_xenergy?.total,
         },
         common: {
             name: {

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -377,7 +377,7 @@ function addPM1(deviceObj, switchId) {
         device_mode: 'pm1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
-            mqtt_publish_funct: value => JSON.parse(value).ret_xenergy?.total,
+            mqtt_publish_funct: value => JSON.parse(value).ret_aenergy?.total,
         },
         common: {
             name: {

--- a/lib/devices/gen2-helper.js
+++ b/lib/devices/gen2-helper.js
@@ -348,7 +348,7 @@ function addPM1(deviceObj, switchId) {
         device_mode: 'pm1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
-            mqtt_publish_funct: value => JSON.parse(value).aenergy.total,
+            mqtt_publish_funct: value => JSON.parse(value).aenergy?.total,
         },
         common: {
             name: {
@@ -377,7 +377,7 @@ function addPM1(deviceObj, switchId) {
         device_mode: 'pm1',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/pm1:${switchId}`,
-            mqtt_publish_funct: value => JSON.parse(value).ret_aenergy.total,
+            mqtt_publish_funct: value => JSON.parse(value).ret_xenergy.total,
         },
         common: {
             name: {
@@ -1035,7 +1035,7 @@ function addSwitch(deviceObj, switchId, hasPowerMetering) {
             device_mode: 'switch',
             mqtt: {
                 mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
-                mqtt_publish_funct: value => JSON.parse(value).aenergy.total,
+                mqtt_publish_funct: value => JSON.parse(value).aenergy?.total,
             },
             common: {
                 name: {
@@ -1064,7 +1064,7 @@ function addSwitch(deviceObj, switchId, hasPowerMetering) {
             device_mode: 'switch',
             mqtt: {
                 mqtt_publish: `<mqttprefix>/status/switch:${switchId}`,
-                mqtt_publish_funct: value => JSON.parse(value).ret_aenergy.total,
+                mqtt_publish_funct: value => JSON.parse(value).ret_aenergy?.total,
             },
             common: {
                 name: {
@@ -2289,7 +2289,7 @@ function addCover(deviceObj, coverId) {
         device_mode: 'cover',
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/cover:${coverId}`,
-            mqtt_publish_funct: value => JSON.parse(value).aenergy.total,
+            mqtt_publish_funct: value => JSON.parse(value).aenergy?.total,
         },
         common: {
             name: {


### PR DESCRIPTION
related #1162

Accessing second level attributes (i.e. ret_aenergy.total) failed if the attribute was not provided by a specific device. This has been fixed. Missing attributes now always return undefined and do not cause exceptions.