### PR TITLE
Fix roles for Gen 2+ input states

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   ### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
+- (@floze-the-genius) Corrected roles for Gen 2+ input states. [#1498]
 - (@klein0r) Updated ble script (v1.4) for Shelly firmware > 2.0
 
 ### 12.0.0-alpha.0 (2026-07-16)

--- a/src/lib/devices/gen2-helper.ts
+++ b/src/lib/devices/gen2-helper.ts
@@ -114,7 +114,7 @@ function addAnalogInput(deviceObj: DeviceDefinition, inputId: number): void {
         common: {
             name: 'Input enable',
             type: 'boolean',
-            role: 'state',
+            role: 'switch.enable',
             read: true,
             write: true,
         },
@@ -137,7 +137,7 @@ function addAnalogInput(deviceObj: DeviceDefinition, inputId: number): void {
         common: {
             name: 'Input Inverted',
             type: 'boolean',
-            role: 'state',
+            role: 'switch',
             read: true,
             write: true,
         },
@@ -1172,7 +1172,7 @@ function addCounterInput(deviceObj: DeviceDefinition, inputId: number): void {
         common: {
             name: 'Input enable',
             type: 'boolean',
-            role: 'state',
+            role: 'switch.enable',
             read: true,
             write: true,
         },
@@ -4148,7 +4148,7 @@ function addInput(deviceObj: DeviceDefinition, inputId: number): void {
         common: {
             name: 'Input enable',
             type: 'boolean',
-            role: 'state',
+            role: 'switch.enable',
             read: true,
             write: true,
         },
@@ -4171,7 +4171,7 @@ function addInput(deviceObj: DeviceDefinition, inputId: number): void {
         common: {
             name: 'Input Inverted',
             type: 'boolean',
-            role: 'state',
+            role: 'switch',
             read: true,
             write: true,
         },
@@ -4185,7 +4185,7 @@ function addInput(deviceObj: DeviceDefinition, inputId: number): void {
         common: {
             name: 'Input Status',
             type: 'boolean',
-            role: 'state',
+            role: 'indicator',
             read: true,
             write: false,
         },

--- a/test/datapoints.test.js
+++ b/test/datapoints.test.js
@@ -44,6 +44,23 @@ describe('Test Device Definitions', function () {
         });
     });
 
+    it('Gen 2+ input states use specific roles', function () {
+        runTestOnEachDevice((deviceClass, device) => {
+            for (const [stateId, state] of Object.entries(device)) {
+                const expectedRoles = {
+                    'Input enable': 'switch.enable',
+                    'Input Inverted': 'switch',
+                    'Input Status': 'indicator',
+                };
+                const expectedRole = expectedRoles[state.common.name];
+
+                if (expectedRole) {
+                    expect(state.common.role, `${deviceClass} (${stateId})`).to.equal(expectedRole);
+                }
+            }
+        });
+    });
+
     it('Protocol properties', function () {
         this.timeout(5000);
 


### PR DESCRIPTION
## Summary

- use `indicator` for read-only input status states
- use `switch.enable` for input enable controls and `switch` for inversion controls
- add regression coverage across generated Gen 2+ device definitions

## Root cause

The shared input component helpers assigned the generic `state` role to boolean status and configuration states, so ioBroker could not distinguish indicators from writable switches.

## Testing

- `npm test`
- `npm run lint`
- `npm run check`
- `npm run build`
- `git diff --check`

Fixes #1498

AI assistance disclosure: This contribution was prepared with OpenAI Codex. I reviewed the diff and validated it with the repository test, lint, typecheck, and build commands.