### PR TITLE
Add monophase mode support to Shelly 3EM G3

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (@mcm1957) Added monophase mode support for Shelly 3EM G3 (shelly3em63g3). [#1540]
+
 ### 12.0.0-alpha.1 (2026-08-19)
 - (@GermanBluefox) Added option to ignore the timezone mismatch message (device timezone differs from the ioBroker host timezone).
 - (@GermanBluefox) Fixed MQTT errors ("Cannot read properties of undefined") if a device closes the connection while it is still being initialized (e.g. battery powered devices).

--- a/src/lib/devices/gen3/shelly3em63g3.ts
+++ b/src/lib/devices/gen3/shelly3em63g3.ts
@@ -6,10 +6,46 @@ import * as shellyHelperGen2 from '../gen2-helper';
  *
  * https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/Shelly3EMG3
  */
-const shelly3em63g3: DeviceDefinition = {};
+const shelly3em63g3: DeviceDefinition = {
+    'Sys.deviceMode': {
+        mqtt: {
+            init_funct: self => self.getDeviceMode(),
+            http_publish: '/rpc/Sys.GetConfig',
+            http_publish_funct: value => (value ? JSON.parse(value).device.profile : undefined),
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Shelly.SetProfile',
+                    params: { name: value },
+                });
+            },
+        },
+        common: {
+            name: 'Mode / Profile',
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: true,
+            states: {
+                triphase: 'triphase ',
+                monophase: 'monophase',
+            },
+        },
+    },
+};
 
 shellyHelperGen2.addEM(shelly3em63g3, 0, ['a', 'b', 'c']);
 shellyHelperGen2.addEMData(shelly3em63g3, 0, ['a', 'b', 'c']);
+
+shellyHelperGen2.addEM1(shelly3em63g3, 0, false);
+shellyHelperGen2.addEM1(shelly3em63g3, 1, false);
+shellyHelperGen2.addEM1(shelly3em63g3, 2, false);
+shellyHelperGen2.addEM1Data(shelly3em63g3, 0);
+shellyHelperGen2.addEM1Data(shelly3em63g3, 1);
+shellyHelperGen2.addEM1Data(shelly3em63g3, 2);
+
 shellyHelperGen2.addEMTemperatureSensor(shelly3em63g3);
 
 export { shelly3em63g3 };


### PR DESCRIPTION
## What changed

Adds monophase mode support to the Shelly 3EM G3 (`shelly3em63g3`), mirroring the existing implementation for the Shelly Pro 3EM (`shellypro3em`):

- Adds the `Sys.deviceMode` state to read/switch the device profile between `triphase` and `monophase` (via `Shelly.SetProfile`).
- Adds the three `EM1` channels (`addEM1` + `addEM1Data` for phases 0/1/2), which are `device_mode`-gated to `monophase` and only appear when the device is in that mode. The existing `addEM`/`addEMData` states remain `triphase`-gated.

## Why

The 3EM G3 supports a monophase profile just like the Pro 3EM, but the adapter only exposed the triphase datapoints. Fixes #1540 (see also #1522, which addressed the same for the old JS implementation).

## Notes for reviewers

- Code intentionally kept minimal and a direct mirror of `src/lib/devices/gen2/shellypro3em.ts`.
- `npm run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)