### PR TITLE
Add support for Shelly Flood S Gen 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   ### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
+- (@mcm1957) Added support for Shelly Flood S Gen 4 (shellyfloodsg4). [#1380]
 - (@mcm1957) Added monophase mode support for Shelly 3EM G3 (shelly3em63g3). [#1540]
 
 ### 12.0.0-alpha.1 (2026-08-19)

--- a/src/lib/datapoints.ts
+++ b/src/lib/datapoints.ts
@@ -103,6 +103,7 @@ import { shellydimmerg4 } from './devices/gen4/shellydimmerg4';
 import { shellyemg4 } from './devices/gen4/shellyemg4';
 import { shellyemminig4 } from './devices/gen4/shellyemminig4';
 import { shellyfloodg4 } from './devices/gen4/shellyfloodg4';
+import { shellyfloodsg4 } from './devices/gen4/shellyfloodsg4';
 import { shellypresence } from './devices/gen4/shellypresence';
 import { shellypstripg4 } from './devices/gen4/shellypstripg4';
 
@@ -216,6 +217,7 @@ const devices: Record<string, DeviceDefinition> = {
     shellyemg4,
     shellyemminig4,
     shellyfloodg4,
+    shellyfloodsg4,
     shellypresence,
     shellypstripg4,
 
@@ -330,6 +332,7 @@ const deviceGen: Record<string, number> = {
     shellyemg4: 4,
     shellyemminig4: 4,
     shellyfloodg4: 4,
+    shellyfloodsg4: 4,
     shellypresence: 4,
     shellypstripg4: 4,
 
@@ -445,6 +448,7 @@ const deviceGroupMap: Record<string, string> = {
     shellyemg4: 'meter',
     shellyemminig4: 'meter',
     shellyfloodg4: 'sensor',
+    shellyfloodsg4: 'sensor',
     shellypresence: 'sensor',
     shellypstripg4: 'light',
 
@@ -559,6 +563,7 @@ const deviceIcons: Record<string, string> = {
     shellyemg4: 'shellyemg3',
     shellyemminig4: 'shellyemminig4',
     shellyfloodg4: 'shellyfloodg4',
+    shellyfloodsg4: 'shellyfloodg4',
     shellypresence: 'shellypresence',
     shellypstripg4: 'shelly2pmg4',
 
@@ -674,6 +679,7 @@ const deviceKnowledgeBase: Record<string, string | undefined> = {
     shellyemg4: 'https://kb.shelly.cloud/knowledge-base/shelly-em-gen4',
     shellyemminig4: 'https://kb.shelly.cloud/knowledge-base/shelly-em-mini-gen4',
     shellyfloodg4: 'https://kb.shelly.cloud/knowledge-base/shelly-flood-gen4',
+    shellyfloodsg4: 'https://kb.shelly.cloud/knowledge-base/shelly-flood-s-gen4',
     shellypresence: 'https://kb.shelly.cloud/knowledge-base/shelly-presence-gen4',
     shellypstripg4: 'https://kb.shelly.cloud/knowledge-base/shelly-power-strip-gen4',
 
@@ -790,6 +796,7 @@ const deviceTypes: Record<string, string[]> = {
     shellyemg4: ['shellyemg4'],
     shellyemminig4: ['shellyemminig4'],
     shellyfloodg4: ['shellyfloodg4'],
+    shellyfloodsg4: ['shellyfloodsg4'],
     shellypresence: ['shellypresence'],
     shellypstripg4: ['shellypstripg4'],
 
@@ -827,6 +834,7 @@ const pollTime: Record<string, number> = {
 
     // Gen 4
     shellyfloodg4: 3600,
+    shellyfloodsg4: 3600,
 };
 
 /**

--- a/src/lib/devices/gen4/shellyfloodsg4.ts
+++ b/src/lib/devices/gen4/shellyfloodsg4.ts
@@ -1,0 +1,42 @@
+import type { DeviceDefinition } from '../../deviceTypes';
+import * as shellyHelperGen2 from '../gen2-helper';
+
+/**
+ * Shelly Flood S Gen 4 / shellyfloodsg4
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen4/ShellyFloodS/
+ */
+const shellyfloodsg4: DeviceDefinition = {
+    'Sys.deviceMode': {
+        mqtt: {
+            init_funct: self => self.getDeviceMode(),
+            http_publish: '/rpc/Sys.GetConfig',
+            http_publish_funct: value => (value ? JSON.parse(value).device.profile : undefined),
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Shelly.SetProfile',
+                    params: { name: value },
+                });
+            },
+        },
+        common: {
+            name: 'Mode / Profile',
+            type: 'string',
+            role: 'state',
+            read: true,
+            write: true,
+            states: {
+                switch: 'relay',
+                cover: 'shutter',
+            },
+        },
+    },
+};
+
+shellyHelperGen2.addDevicePower(shellyfloodsg4, 0, false);
+shellyHelperGen2.addFlood(shellyfloodsg4, 0);
+
+export { shellyfloodsg4 };


### PR DESCRIPTION
## What changed
Adds support for the **Shelly Flood S Gen 4** (`shellyfloodsg4`).

- New device module `src/lib/devices/gen4/shellyfloodsg4.ts`, mirroring the existing Flood Gen 4. It reuses the `DevicePower` and `Flood` components from `gen2-helper.ts` (both already existed) via `addDevicePower(…, 0, false)` and `addFlood(…, 0)`.
- Registered the device in `src/lib/datapoints.ts` across all maps (import, `devices`, `deviceGen`, `deviceGroupMap`, `deviceIcons`, `deviceKnowledgeBase`, `deviceTypes`, `pollTime`), keeping alphabetic ordering.
- Icon falls back to the existing `shellyfloodg4.png`.
- Changelog entry added to README.md.

## Why
Refers to #1380 — hardware support request for the newly announced Shelly Flood S Gen 4.

## Notes for reviewer
The Gen4 API docs did not state the exact `app`/type string, so the device id follows the existing naming convention (`shellyfloodsg4`). If the physical device reports a different type id, the `deviceTypes` entry in `datapoints.ts` is the single line to adjust.

`npm run check` and `npm run build` pass.