### PR TITLE
Add support for Top AC Portable EV Charger

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Notes:
 | LinkedGo Smart Thermost (st1820)              | ❌   | >= v10.6.0 |
 | Ogemray 25A (ogemray25a)                      | ❌   | >= v9.5.0  |
 | Shelly Cury (cury)                            | ❌   | >= v11.0.0 |
+| Top AC Portable EV Charger (topacportableevcharger) | ❌   | >= v12.0.0 |
 
 ### Bluetooth Low Energy (BLU)
 
@@ -223,6 +224,7 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   ### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
+- (@mcm1957) Added support for Top AC Portable EV Charger (topacportableevcharger). [#1401]
 - (@mcm1957) Added support for Shelly Flood S Gen 4 (shellyfloodsg4). [#1380]
 - (@mcm1957) Added monophase mode support for Shelly 3EM G3 (shelly3em63g3). [#1540]
 

--- a/src/lib/datapoints.ts
+++ b/src/lib/datapoints.ts
@@ -113,6 +113,7 @@ import { hiluxds8 } from './devices/poweredbyshelly/hiluxds8';
 import { irrigation } from './devices/poweredbyshelly/irrigation';
 import { ogemray25a } from './devices/poweredbyshelly/ogemray25a';
 import { st1820 } from './devices/poweredbyshelly/st1820';
+import { topacportableevcharger } from './devices/poweredbyshelly/topacportableevcharger';
 import { watervalve } from './devices/poweredbyshelly/watervalve';
 
 const devices: Record<string, DeviceDefinition> = {
@@ -227,6 +228,7 @@ const devices: Record<string, DeviceDefinition> = {
     irrigation,
     ogemray25a,
     st1820,
+    topacportableevcharger,
     watervalve,
 };
 
@@ -342,6 +344,7 @@ const deviceGen: Record<string, number> = {
     irrigation: 3,
     ogemray25a: 3,
     st1820: 3,
+    topacportableevcharger: 3,
     watervalve: 3,
 };
 
@@ -458,6 +461,7 @@ const deviceGroupMap: Record<string, string> = {
     irrigation: 'other',
     ogemray25a: 'other',
     st1820: 'other',
+    topacportableevcharger: 'other',
     watervalve: 'other',
 };
 
@@ -573,6 +577,7 @@ const deviceIcons: Record<string, string> = {
     irrigation: 'shellyplus1',
     ogemray25a: 'shellyplus1',
     st1820: 'shellyplus1',
+    topacportableevcharger: 'shellyplus1',
     watervalve: 'shellyplus1',
 };
 
@@ -689,6 +694,7 @@ const deviceKnowledgeBase: Record<string, string | undefined> = {
     irrigation: undefined, // no knowledgebase entry exists
     ogemray25a: 'https://www.shelly.com/de/products/ogemray-25a-smart-relay',
     st1820: undefined, // no knowledgebase entry exists,
+    topacportableevcharger: undefined, // no knowledgebase entry exists,
     watervalve: undefined, // no knowledgebase entry exists,
 };
 
@@ -806,6 +812,7 @@ const deviceTypes: Record<string, string[]> = {
     irrigation: ['irrigation'],
     ogemray25a: ['ogemray25a'],
     st1820: ['st1820'],
+    topacportableevcharger: ['topacportableevcharger'],
     watervalve: ['watervalve'],
 };
 

--- a/src/lib/devices/poweredbyshelly/topacportableevcharger.ts
+++ b/src/lib/devices/poweredbyshelly/topacportableevcharger.ts
@@ -1,0 +1,267 @@
+import type { DeviceDefinition } from '../../deviceTypes';
+
+/**
+ * Top AC Portable EV Charger / topacportableevcharger
+ *
+ * This device does not provide a device type, so 'topacportableevcharger' is used as deviceId.
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyX/XT1/TopACPortableEVCharger
+ */
+const topacportableevcharger: DeviceDefinition = {
+    'Charger.WorkState': {
+        mqtt: {
+            http_publish: '/rpc/Enum.GetStatus?owner="service:0"&role="work_state"',
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+        },
+        common: {
+            name: 'Work state',
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: false,
+        },
+    },
+    'Charger.CurrentLimit': {
+        mqtt: {
+            http_publish: '/rpc/Number.GetStatus?owner="service:0"&role="current_limit"',
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Number.Set',
+                    params: { owner: 'service:0', role: 'current_limit', value: value },
+                });
+            },
+        },
+        common: {
+            name: 'Current limit',
+            type: 'number',
+            role: 'level',
+            unit: 'A',
+            read: true,
+            write: true,
+        },
+    },
+    'Charger.StartCharging': {
+        mqtt: {
+            http_publish: '/rpc/Boolean.GetStatus?owner="service:0"&role="start_charging"',
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Boolean.Set',
+                    params: { owner: 'service:0', role: 'start_charging', value: value },
+                });
+            },
+        },
+        common: {
+            name: 'Start charging',
+            type: 'boolean',
+            role: 'switch',
+            read: true,
+            write: true,
+        },
+    },
+    'Charger.EnergyCharge': {
+        mqtt: {
+            http_publish: '/rpc/Number.GetStatus?owner="service:0"&role="energy_charge"',
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+        },
+        common: {
+            name: 'Session energy consumption',
+            type: 'number',
+            role: 'value.energy',
+            unit: 'kWh',
+            read: true,
+            write: false,
+        },
+    },
+    'Charger.TimeCharge': {
+        mqtt: {
+            http_publish: '/rpc/Number.GetStatus?owner="service:0"&role="time_charge"',
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+        },
+        common: {
+            name: 'Session duration',
+            type: 'number',
+            role: 'value',
+            unit: 'min',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.TotalCurrent': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.total_current : undefined),
+        },
+        common: {
+            name: 'Total current',
+            type: 'number',
+            role: 'value.current',
+            unit: 'A',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.TotalPower': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.total_power : undefined),
+        },
+        common: {
+            name: 'Total power',
+            type: 'number',
+            role: 'value.power',
+            unit: 'W',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.TotalActEnergy': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.total_act_energy : undefined),
+        },
+        common: {
+            name: 'Total active energy',
+            type: 'number',
+            role: 'value.energy',
+            unit: 'kWh',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseAVoltage': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_a.voltage : undefined),
+        },
+        common: {
+            name: 'Phase A voltage',
+            type: 'number',
+            role: 'value.voltage',
+            unit: 'V',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseACurrent': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_a.current : undefined),
+        },
+        common: {
+            name: 'Phase A current',
+            type: 'number',
+            role: 'value.current',
+            unit: 'A',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseAPower': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_a.power : undefined),
+        },
+        common: {
+            name: 'Phase A power',
+            type: 'number',
+            role: 'value.power',
+            unit: 'W',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseBVoltage': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_b.voltage : undefined),
+        },
+        common: {
+            name: 'Phase B voltage',
+            type: 'number',
+            role: 'value.voltage',
+            unit: 'V',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseBCurrent': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_b.current : undefined),
+        },
+        common: {
+            name: 'Phase B current',
+            type: 'number',
+            role: 'value.current',
+            unit: 'A',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseBPower': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_b.power : undefined),
+        },
+        common: {
+            name: 'Phase B power',
+            type: 'number',
+            role: 'value.power',
+            unit: 'W',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseCVoltage': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_c.voltage : undefined),
+        },
+        common: {
+            name: 'Phase C voltage',
+            type: 'number',
+            role: 'value.voltage',
+            unit: 'V',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseCCurrent': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_c.current : undefined),
+        },
+        common: {
+            name: 'Phase C current',
+            type: 'number',
+            role: 'value.current',
+            unit: 'A',
+            read: true,
+            write: false,
+        },
+    },
+    'PhaseInfo.PhaseCPower': {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="phase_info"',
+            http_publish_funct: value => (value ? JSON.parse(value).value.phase_c.power : undefined),
+        },
+        common: {
+            name: 'Phase C power',
+            type: 'number',
+            role: 'value.power',
+            unit: 'W',
+            read: true,
+            write: false,
+        },
+    },
+};
+
+export { topacportableevcharger };


### PR DESCRIPTION
## What

Adds the "Powered By Shelly" **Top AC Portable EV Charger** as a new supported device (`topacportableevcharger`).

## Why

Requested in #1401.

## Details

- The device exposes no device type, so `topacportableevcharger` is used as the deviceId (as instructed in the issue).
- It only provides role-based virtual components under `service:0` (no standard components), so no helpers were added to `gen2-helper.ts`. The datapoints are defined manually in the new device module:
  - `Charger.WorkState` – charging state (read)
  - `Charger.CurrentLimit` – charging current in A (read/write → `Number.Set`)
  - `Charger.StartCharging` – start/stop session (read/write → `Boolean.Set`)
  - `Charger.EnergyCharge` / `Charger.TimeCharge` – session energy/duration (read)
  - `PhaseInfo.*` – total current/power/energy and per-phase A/B/C voltage/current/power (read)
- Read values are polled via the documented role-based RPC endpoints (`Enum/Number/Boolean/Object.GetStatus`); writes go via MQTT RPC.
- Registered in `datapoints.ts` (`devices`, `deviceGen`, `deviceGroupMap`, `deviceIcons`, `deviceKnowledgeBase`, `deviceTypes`) and documented in `README.md` (changelog + supported-device table).

Refers to #1401

## Testing

- `npm run build` succeeds
- `npm run test:js` – all 27 tests pass (incl. 21 datapoint-registry tests)
- New device module lints clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
