### PR TITLE
Make dimmer transition time writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   ### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
+- (@mcm1957) The transition time can now be written for Shelly Dimmer1/Dimmer2 and for Gen2+ dimmers/lights (incl. Dimmer Gen3 and Dimmer Gen4). [#1214][#1224]
 - (@mcm1957) Added support for Top AC Portable EV Charger (topacportableevcharger) - **EXPERIMENTAL ONLY** [#1401]
 - (@mcm1957) Added support for Shelly Flood S Gen 4 (shellyfloodsg4). [#1380]
 - (@mcm1957) Added monophase mode support for Shelly 3EM G3 (shelly3em63g3). [#1540]

--- a/src/lib/devices/gen1/shellydimmer.ts
+++ b/src/lib/devices/gen1/shellydimmer.ts
@@ -419,17 +419,21 @@ const shellydimmer: DeviceDefinition = {
         coap: {
             http_publish: '/settings',
             http_publish_funct: value => (value ? JSON.parse(value).transition : undefined),
+            http_cmd: '/settings/light/0',
+            http_cmd_funct: value => ({ transition: value }),
         },
         mqtt: {
             http_publish: '/settings',
             http_publish_funct: value => (value ? JSON.parse(value).transition : undefined),
+            http_cmd: '/settings/light/0',
+            http_cmd_funct: value => ({ transition: value }),
         },
         common: {
             name: 'Fade Rate',
             type: 'number',
             role: 'state',
             read: true,
-            write: false,
+            write: true,
             unit: 'ms',
             min: 0,
             max: 5000,

--- a/src/lib/devices/gen1/shellydimmer2.ts
+++ b/src/lib/devices/gen1/shellydimmer2.ts
@@ -417,17 +417,21 @@ const shellydimmer2: DeviceDefinition = {
         coap: {
             http_publish: '/settings',
             http_publish_funct: value => (value ? JSON.parse(value).transition : undefined),
+            http_cmd: '/settings/light/0',
+            http_cmd_funct: value => ({ transition: value }),
         },
         mqtt: {
             http_publish: '/settings',
             http_publish_funct: value => (value ? JSON.parse(value).transition : undefined),
+            http_cmd: '/settings/light/0',
+            http_cmd_funct: value => ({ transition: value }),
         },
         common: {
             name: 'Transitions Time',
             type: 'number',
             role: 'state',
             read: true,
-            write: false,
+            write: true,
             unit: 'ms',
             min: 0,
             max: 5000,

--- a/src/lib/devices/gen2-helper.ts
+++ b/src/lib/devices/gen2-helper.ts
@@ -4439,6 +4439,31 @@ function addLight(deviceObj: DeviceDefinition, lightId: number, hasPowerMetering
         },
     };
 
+    deviceObj[`Light${lightId}.transition`] = {
+        mqtt: {
+            mqtt_publish: `<mqttprefix>/status/light:${lightId}`,
+            mqtt_publish_funct: value => JSON.parse(value)?.transition?.duration,
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Light.Set',
+                    params: { id: lightId, transition_duration: value },
+                });
+            },
+        },
+        common: {
+            name: 'Transition Time',
+            type: 'number',
+            role: 'value',
+            def: 0,
+            unit: 's',
+            read: true,
+            write: true,
+        },
+    };
+
     deviceObj[`Light${lightId}.CalibrationProgress`] = {
         mqtt: {
             mqtt_publish: `<mqttprefix>/status/light:${lightId}`,


### PR DESCRIPTION
## What changed

- **Gen1 Dimmer1/Dimmer2** (`shellydimmer.ts`, `shellydimmer2.ts`): the `lights.Transiton` state was read-only. Added `http_cmd: '/settings/light/0'` with `http_cmd_funct: value => ({ transition: value })` to the `coap` and `mqtt` blocks and set `write: true`, mirroring the working pattern already used in `shellyrgbw2.ts`.
- **Gen2+ lights/dimmers** (`gen2-helper.ts` `addLight()`): added a writable `Light<id>.transition` datapoint (`Light.Set` with `transition_duration`), mirroring the existing RGB/RGBW `transition` convention. This gives Dimmer Gen3, Dimmer Gen4, and all other `addLight()`-based devices a writable transition. The read-only `Transition_Duration` status datapoint is left untouched.

## Why

Refers to #1214 (transition no longer writable for Dimmer1/2, RGBW; missing on Dimmer Gen3) and #1224 (transition missing on Dimmer Gen4). Transition time control is essential for lighting scenes/fades.

## Notes for reviewers

Following the existing RGB/RGBW convention, writing `Light.transition` sends a standalone `Light.Set` carrying only `transition_duration` (setting the duration used for transitions) rather than folding it into every Switch/Brightness command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)