### PR TITLE
Add support for Shelly Duo Bulb E27 Gen 3 (shellyduobulbg3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (@mcm1957) Added support for Shelly Duo Bulb E27 Gen 3 (shellyduobulbg3). [#1385]
+
 ### 12.0.0-alpha.2 (2026-08-19)
 - (@mcm1957) The transition time can now be written for Shelly Dimmer1/Dimmer2 and for Gen2+ dimmers/lights (incl. Dimmer Gen3 and Dimmer Gen4). [#1214][#1224]
 - (@mcm1957) Added support for Top AC Portable EV Charger (topacportableevcharger) - **EXPERIMENTAL ONLY** [#1401]

--- a/src/lib/datapoints.ts
+++ b/src/lib/datapoints.ts
@@ -81,6 +81,7 @@ import { shellyazplug } from './devices/gen3/shellyazplug';
 import { shellyblugwg3 } from './devices/gen3/shellyblugwg3';
 import { shellyddimmerg3 } from './devices/gen3/shellyddimmerg3';
 import { shellydimmerg3 } from './devices/gen3/shellydimmerg3';
+import { shellyduobulbg3 } from './devices/gen3/shellyduobulbg3';
 import { shellyemg3 } from './devices/gen3/shellyemg3';
 import { shellyhtg3 } from './devices/gen3/shellyhtg3';
 import { shellyi4g3 } from './devices/gen3/shellyi4g3';
@@ -196,6 +197,7 @@ const devices: Record<string, DeviceDefinition> = {
     shellyblugwg3,
     shellyddimmerg3,
     shellydimmerg3,
+    shellyduobulbg3,
     shellyemg3,
     shellyhtg3,
     shellyi4g3,
@@ -312,6 +314,7 @@ const deviceGen: Record<string, number> = {
     shellyblugwg3: 3,
     shellyddimmerg3: 3,
     shellydimmerg3: 3,
+    shellyduobulbg3: 3,
     shellyemg3: 3,
     shellyhtg3: 3,
     shellyi4g3: 3,
@@ -429,6 +432,7 @@ const deviceGroupMap: Record<string, string> = {
     shellyblugwg3: 'gateway',
     shellyddimmerg3: 'dimmer',
     shellydimmerg3: 'dimmer',
+    shellyduobulbg3: 'light',
     shellyemg3: 'meter',
     shellyhtg3: 'sensor',
     shellyi4g3: 'input',
@@ -545,6 +549,7 @@ const deviceIcons: Record<string, string> = {
     shellyblugwg3: 'shellyblugwg3',
     shellyddimmerg3: 'shellydimmerg3',
     shellydimmerg3: 'shellydimmerg3',
+    shellyduobulbg3: 'shellybulbduo',
     shellyemg3: 'shellyemg3',
     shellyhtg3: 'shellyhtg3',
     shellyi4g3: 'shellyi4g3',
@@ -662,6 +667,7 @@ const deviceKnowledgeBase: Record<string, string | undefined> = {
     shellyblugwg3: 'https://kb.shelly.cloud/knowledge-base/shelly-blu-gateway-gen3',
     shellyddimmerg3: 'https://kb.shelly.cloud/knowledge-base/shelly-dali-dimmer-gen3',
     shellydimmerg3: 'https://kb.shelly.cloud/knowledge-base/shelly-dimmer-gen3',
+    shellyduobulbg3: 'https://kb.shelly.cloud/knowledge-base/shelly-duo-bulb-e27-gen3',
     shellyemg3: 'https://kb.shelly.cloud/knowledge-base/shelly-em-gen3',
     shellyhtg3: 'https://kb.shelly.cloud/knowledge-base/shelly-h-t-gen3',
     shellyi4g3: 'https://kb.shelly.cloud/knowledge-base/shelly-i4-gen3',
@@ -780,6 +786,7 @@ const deviceTypes: Record<string, string[]> = {
     shellyblugwg3: ['shellyblugwg3'],
     shellyddimmerg3: ['shellyddimmerg3'],
     shellydimmerg3: ['shellydimmerg3'],
+    shellyduobulbg3: ['shellyduobulbg3'],
     shellyemg3: ['shellyemg3'],
     shellyhtg3: ['shellyhtg3'],
     shellyi4g3: ['shellyi4g3'],

--- a/src/lib/devices/gen3/shellyduobulbg3.ts
+++ b/src/lib/devices/gen3/shellyduobulbg3.ts
@@ -1,0 +1,15 @@
+import type { DeviceDefinition } from '../../deviceTypes';
+import * as shellyHelperGen2 from '../gen2-helper';
+
+/**
+ * Shelly Duo Bulb E27 Gen 3 / shellyduobulbg3 / S3BL-D010009AEU
+ *
+ * Tunable white bulb (2700 K - 6500 K) with power metering, uses the CCT component.
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/CCT
+ */
+const shellyduobulbg3: DeviceDefinition = {};
+
+shellyHelperGen2.addCCT(shellyduobulbg3, 0, true);
+
+export { shellyduobulbg3 };


### PR DESCRIPTION
## What changed

Adds device support for the **Shelly Duo Bulb E27 Gen 3** (`shellyduobulbg3`, model S3BL-D010009AEU), a Gen3 tunable-white bulb (2700–6500 K) with power metering.

- **New** `src/lib/devices/gen3/shellyduobulbg3.ts` — device definition built on the existing Gen2+ **CCT component** helper (`shellyHelperGen2.addCCT(obj, 0, true)`; `true` enables power metering).
- `src/lib/datapoints.ts` — registered the model in all relevant maps: import + `devices`, `deviceGen` (3), `deviceGroupMap` (`light`), `deviceIcons`, `deviceKnowledgeBase`, and `deviceTypes`.
- `README.md` — changelog entry.

## Why

Requested in issue #1385.

## Notes for reviewers

- Device characteristics (CCT component, 2700–6500 K, power metering) were confirmed from the Shelly product page / KB, as the issue did not include a device status/config JSON dump.
- The bulb reuses the existing `shellybulbduo.png` icon as a fallback; a dedicated product icon could be added later.
- Verified: `npm run build` succeeds and the datapoints unit tests (21) pass.

refers to #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)