### PR TITLE
Add i18n validation tests for datapoint names

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (@mcm1957) Added tests to validate that all datapoint names are translated and that all i18n language files are consistent.
+
 ### 12.0.0-alpha.2 (2026-08-19)
 - (@mcm1957) The transition time can now be written for Shelly Dimmer1/Dimmer2 and for Gen2+ dimmers/lights (incl. Dimmer Gen3 and Dimmer Gen4). [#1214][#1224]
 - (@mcm1957) Added support for Top AC Portable EV Charger (topacportableevcharger) - **EXPERIMENTAL ONLY** [#1401]

--- a/test/datapoints.test.js
+++ b/test/datapoints.test.js
@@ -540,25 +540,67 @@ describe('Test i18n translations', function () {
 
     const langFiles = fs.readdirSync(i18nDir).filter(file => file.endsWith('.json'));
 
-    it('Every "name" used in object creation exists as key in src/i18n/en.json', function () {
-        this.timeout(5000);
+    // Recursively collect all device source files so a missing name can be traced to its file
+    function collectDeviceSourceFiles(dir) {
+        const result = [];
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                result.push(...collectDeviceSourceFiles(fullPath));
+            } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+                result.push(fullPath);
+            }
+        }
+        return result;
+    }
 
-        const missing = new Set();
+    function findSourceFilesForName(name) {
+        const devicesDir = path.join(__dirname, '..', 'src', 'lib', 'devices');
+        const files = collectDeviceSourceFiles(devicesDir);
+        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        // Match name: 'value' / "value" / `value`
+        const regex = new RegExp(`name:\\s*(['"\`])${escaped}\\1`);
+        const matches = [];
+        for (const file of files) {
+            if (regex.test(fs.readFileSync(file, 'utf8'))) {
+                matches.push(path.relative(path.join(__dirname, '..'), file).replace(/\\/g, '/'));
+            }
+        }
+        return matches;
+    }
+
+    it('Every "name" used in object creation exists as key in src/i18n/en.json', function () {
+        this.timeout(10000);
+
+        // key => missing name, value => Set of "deviceClass (stateId)" occurrences
+        const missing = new Map();
 
         runTestOnEachDevice((deviceClass, device) => {
             for (const stateId in device) {
                 const name = device[stateId]?.common?.name;
 
                 if (typeof name === 'string' && !Object.prototype.hasOwnProperty.call(en, name)) {
-                    missing.add(`${name}  (${deviceClass} - ${stateId})`);
+                    if (!missing.has(name)) {
+                        missing.set(name, new Set());
+                    }
+                    missing.get(name).add(`${deviceClass} (${stateId})`);
                 }
             }
         });
 
-        expect(
-            [...missing],
-            `The following "name" values are missing as keys in src/i18n/en.json`,
-        ).to.be.an('array').that.is.empty;
+        if (missing.size > 0) {
+            const lines = [];
+            for (const [name, occurrences] of missing) {
+                const files = findSourceFilesForName(name);
+                lines.push(`  - Missing key: "${name}"`);
+                lines.push(`      used in: ${[...occurrences].join(', ')}`);
+                lines.push(`      file(s): ${files.length ? files.join(', ') : '(source file not located)'}`);
+            }
+
+            expect.fail(
+                `${missing.size} "name" value(s) are missing as keys in src/i18n/en.json:\n${lines.join('\n')}`,
+            );
+        }
     });
 
     it('Every key in src/i18n/en.json exists in all other src/i18n/*.json files', function () {

--- a/test/datapoints.test.js
+++ b/test/datapoints.test.js
@@ -533,6 +533,65 @@ describe('Test Device Definitions', function () {
     });
 });
 
+describe('Test i18n translations', function () {
+    const i18nDir = path.join(__dirname, '..', 'src', 'i18n');
+    const enPath = path.join(i18nDir, 'en.json');
+    const en = JSON.parse(fs.readFileSync(enPath, 'utf8'));
+
+    const langFiles = fs.readdirSync(i18nDir).filter(file => file.endsWith('.json'));
+
+    it('Every "name" used in object creation exists as key in src/i18n/en.json', function () {
+        this.timeout(5000);
+
+        const missing = new Set();
+
+        runTestOnEachDevice((deviceClass, device) => {
+            for (const stateId in device) {
+                const name = device[stateId]?.common?.name;
+
+                if (typeof name === 'string' && !Object.prototype.hasOwnProperty.call(en, name)) {
+                    missing.add(`${name}  (${deviceClass} - ${stateId})`);
+                }
+            }
+        });
+
+        expect(
+            [...missing],
+            `The following "name" values are missing as keys in src/i18n/en.json`,
+        ).to.be.an('array').that.is.empty;
+    });
+
+    it('Every key in src/i18n/en.json exists in all other src/i18n/*.json files', function () {
+        const enKeys = Object.keys(en);
+
+        for (const langFile of langFiles) {
+            if (langFile === 'en.json') {
+                continue;
+            }
+
+            const lang = JSON.parse(fs.readFileSync(path.join(i18nDir, langFile), 'utf8'));
+            const missing = enKeys.filter(key => !Object.prototype.hasOwnProperty.call(lang, key));
+
+            expect(missing, `Keys missing in src/i18n/${langFile}`).to.be.an('array').that.is.empty;
+        }
+    });
+
+    it('No key exists in any src/i18n/*.json file which is missing in src/i18n/en.json', function () {
+        for (const langFile of langFiles) {
+            if (langFile === 'en.json') {
+                continue;
+            }
+
+            const lang = JSON.parse(fs.readFileSync(path.join(i18nDir, langFile), 'utf8'));
+            const extra = Object.keys(lang).filter(key => !Object.prototype.hasOwnProperty.call(en, key));
+
+            expect(extra, `Keys in src/i18n/${langFile} that are missing in src/i18n/en.json`).to.be.an(
+                'array',
+            ).that.is.empty;
+        }
+    });
+});
+
 describe('Test Device Registry Completeness', function () {
     const deviceKeys = Object.keys(devices);
 


### PR DESCRIPTION
## What changed

Extends `test/datapoints.test.js` with a new `Test i18n translations` suite containing three checks:

1. Every `name` string used in datapoint object creation exists as a key in `src/i18n/en.json`.
2. Every key present in `src/i18n/en.json` exists in all other `src/i18n/*.json` language files.
3. No key exists in any `src/i18n/*.json` file that is missing from `src/i18n/en.json`.

## Why

These tests guard the translation pipeline: they ensure datapoint names are always translatable and that the per-language dictionaries stay in sync with the English reference.

## Reviewer notes

- Checks 2 and 3 currently **pass** — all language files are consistent with `en.json`.
- Check 1 currently **fails**: it surfaces 94 distinct `name` values (376 occurrences, mostly older/gen1 devices) that are used in device definitions but have no entry in `en.json`. This is a genuine pre-existing gap the test now makes visible. It is left failing intentionally as a TODO tracker; adding the missing keys to all 11 i18n files can follow separately.
- The tests read compiled output from `build/`, so `npm run build` must run before `npm run test:js`.

Refers to i18n datapoint name validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)