### PR TITLE
Validate common.desc translations in datapoint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
 -->
 ### **WORK IN PROGRESS**
 - (@mcm1957) Added the missing translations for all datapoint names in all supported languages.
-- (@mcm1957) Added tests to validate that all datapoint names are translated and that all i18n language files are consistent.
+- (@mcm1957) Added tests to validate that all datapoint names and descriptions are translated and that all i18n language files are consistent.
 - (@mcm1957) Added support for Shelly Duo Bulb E27 Gen 3 (shellyduobulbg3). [#1385]
 
 ### 12.0.0-alpha.2 (2026-08-19)

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -128,6 +128,7 @@
     "Generation": "Generation",
     "Generic status notifications enabled": "Allgemeine Statusbenachrichtigungen aktiviert",
     "Green": "Grün",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Hilfe: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Hochfrequenz",
     "Hue": "Farbton",
     "Humidity": "Luftfeuchtigkeit",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -128,6 +128,7 @@
     "Generation": "Generation",
     "Generic status notifications enabled": "Generic status notifications enabled",
     "Green": "Green",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "High Frequency",
     "Hue": "Hue",
     "Humidity": "Humidity",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -128,6 +128,7 @@
     "Generation": "Generación",
     "Generic status notifications enabled": "Se han habilitado notificaciones de estado genérico",
     "Green": "Verde",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Ayuda: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Alta frecuencia",
     "Hue": "Matiz",
     "Humidity": "Humedad",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -128,6 +128,7 @@
     "Generation": "Génération",
     "Generic status notifications enabled": "Notifications d'état générique activé",
     "Green": "Vert",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Aide: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Haute fréquence",
     "Hue": "Teinte",
     "Humidity": "Humidité",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -128,6 +128,7 @@
     "Generation": "Generazione",
     "Generic status notifications enabled": "Notifiche di stato generiche abilitate",
     "Green": "Verde",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Aiuto: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Alta frequenza",
     "Hue": "Tonalità",
     "Humidity": "Umidità",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -128,6 +128,7 @@
     "Generation": "Generatie",
     "Generic status notifications enabled": "Generische status melding",
     "Green": "Groen",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Hoge frequentie",
     "Hue": "Tint",
     "Humidity": "Vochtigheid",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -128,6 +128,7 @@
     "Generation": "Generacja",
     "Generic status notifications enabled": "Statystyki genetyczne umożliwiły",
     "Green": "Zielony",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Pomoc: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Wysoka częstotliwość",
     "Hue": "Odcień",
     "Humidity": "Wilgotność",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -128,6 +128,7 @@
     "Generation": "Geração",
     "Generic status notifications enabled": "Notificações de status genéricas activadas",
     "Green": "Verde",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Ajuda: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Alta frequência",
     "Hue": "Matiz",
     "Humidity": "Umidade",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -128,6 +128,7 @@
     "Generation": "Поколение",
     "Generic status notifications enabled": "Уведомления о генерическом статусе включены",
     "Green": "Зелёный",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Справка: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Высокая частота",
     "Hue": "Оттенок",
     "Humidity": "Влажность",

--- a/src/i18n/uk.json
+++ b/src/i18n/uk.json
@@ -128,6 +128,7 @@
     "Generation": "Покоління",
     "Generic status notifications enabled": "Увімкнути повідомлення про статус",
     "Green": "Зелений",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "Довідка: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "Висока частота",
     "Hue": "Відтінок",
     "Humidity": "Вологість",

--- a/src/i18n/zh-cn.json
+++ b/src/i18n/zh-cn.json
@@ -128,6 +128,7 @@
     "Generation": "一代",
     "Generic status notifications enabled": "基因身份通知使得",
     "Green": "绿色",
+    "Help: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md": "帮助: https://github.com/iobroker-community-adapters/ioBroker.shelly/blob/master/docs/en/ble-devices.md",
     "High Frequency": "高频率",
     "Hue": "色调",
     "Humidity": "湿度",

--- a/test/datapoints.test.js
+++ b/test/datapoints.test.js
@@ -554,12 +554,12 @@ describe('Test i18n translations', function () {
         return result;
     }
 
-    function findSourceFilesForName(name) {
+    function findSourceFilesForAttribute(attribute, value) {
         const devicesDir = path.join(__dirname, '..', 'src', 'lib', 'devices');
         const files = collectDeviceSourceFiles(devicesDir);
-        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        // Match name: 'value' / "value" / `value`
-        const regex = new RegExp(`name:\\s*(['"\`])${escaped}\\1`);
+        const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        // Match attribute: 'value' / "value" / `value`
+        const regex = new RegExp(`${attribute}:\\s*(['"\`])${escaped}\\1`);
         const matches = [];
         for (const file of files) {
             if (regex.test(fs.readFileSync(file, 'utf8'))) {
@@ -569,38 +569,46 @@ describe('Test i18n translations', function () {
         return matches;
     }
 
-    it('Every "name" used in object creation exists as key in src/i18n/en.json', function () {
-        this.timeout(10000);
-
-        // key => missing name, value => Set of "deviceClass (stateId)" occurrences
+    function assertAttributeTranslated(attribute) {
+        // key => missing value, value => Set of "deviceClass (stateId)" occurrences
         const missing = new Map();
 
         runTestOnEachDevice((deviceClass, device) => {
             for (const stateId in device) {
-                const name = device[stateId]?.common?.name;
+                const value = device[stateId]?.common?.[attribute];
 
-                if (typeof name === 'string' && !Object.prototype.hasOwnProperty.call(en, name)) {
-                    if (!missing.has(name)) {
-                        missing.set(name, new Set());
+                if (typeof value === 'string' && !Object.prototype.hasOwnProperty.call(en, value)) {
+                    if (!missing.has(value)) {
+                        missing.set(value, new Set());
                     }
-                    missing.get(name).add(`${deviceClass} (${stateId})`);
+                    missing.get(value).add(`${deviceClass} (${stateId})`);
                 }
             }
         });
 
         if (missing.size > 0) {
             const lines = [];
-            for (const [name, occurrences] of missing) {
-                const files = findSourceFilesForName(name);
-                lines.push(`  - Missing key: "${name}"`);
+            for (const [value, occurrences] of missing) {
+                const files = findSourceFilesForAttribute(attribute, value);
+                lines.push(`  - Missing key: "${value}"`);
                 lines.push(`      used in: ${[...occurrences].join(', ')}`);
                 lines.push(`      file(s): ${files.length ? files.join(', ') : '(source file not located)'}`);
             }
 
             expect.fail(
-                `${missing.size} "name" value(s) are missing as keys in src/i18n/en.json:\n${lines.join('\n')}`,
+                `${missing.size} "${attribute}" value(s) are missing as keys in src/i18n/en.json:\n${lines.join('\n')}`,
             );
         }
+    }
+
+    it('Every "name" used in object creation exists as key in src/i18n/en.json', function () {
+        this.timeout(10000);
+        assertAttributeTranslated('name');
+    });
+
+    it('Every "desc" used in object creation exists as key in src/i18n/en.json', function () {
+        this.timeout(10000);
+        assertAttributeTranslated('desc');
     });
 
     it('Every key in src/i18n/en.json exists in all other src/i18n/*.json files', function () {


### PR DESCRIPTION
## What changed

Extends the i18n validation tests so that `common.desc` strings are checked the same way `common.name` already is: every `desc` string used in datapoint object creation must exist as a key in `src/i18n/en.json`.

- Refactored the existing name check into a reusable helper (`assertAttributeTranslated`) and added a new test for `desc`.
- The check found one `desc` value missing from the i18n dictionary (a help URL); added that key to `en.json` and all other language files, keeping alphabetic order and file formatting.

## Why

Datapoint descriptions are shown to users and should be translatable just like names. This guards against untranslated `desc` strings slipping in.

## Reviewer notes

- All 25 tests in `test/datapoints.test.js` pass, including the new `desc` check.
- Language-file changes are purely additive; formatting (4-space indent, CRLF, no trailing newline) is preserved.

Refers to #1564 and #1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)