### PR TITLE
feat: reach Gen 2+ devices that sit behind a Shelly Range Extender

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It uses the default Shelly firmware (no flashing of firmware needed!). You will 
 
 ## Supported devices
 
-Note that devices connected using **Shellies Range Extender** functionality are **not supported**.  
+Note that Gen 1 devices connected using **Shellies Range Extender** functionality are **not supported**. Gen 2+ devices behind a range extender are reached over the port the extender maps for them.  
 Please connect your devices directly to your (W)LAN and use a classic WLAN Repeater if required.
 
 ### Generation 1 (Gen 1)
@@ -225,6 +225,7 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
 <!--
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
+- () Added support for Shelly Gen2+ devices connected through a Shelly Range Extender.
 -->
 ### **WORK IN PROGRESS**
 - (@mcm1957) Added the missing translations for all datapoint names in all supported languages.

--- a/src/lib/deviceTypes.ts
+++ b/src/lib/deviceTypes.ts
@@ -46,6 +46,8 @@ export interface ShellyClient {
     deviceId: string | undefined;
     /** Current IP address of the device, e.g. `192.168.1.2`. */
     ip: string | undefined;
+    /** Host (and port) HTTP requests go to, e.g. `192.168.1.3:23456` behind a range extender. */
+    httpEndpoint: string | undefined;
     /** Device id reported by the device, e.g. `shellyplug-s-12345`. */
     id: string | undefined;
     /** Hardware type, e.g. `SHRGBW2`. */
@@ -70,6 +72,8 @@ export interface ShellyClient {
     getDirectoryName: () => string;
     getDeviceMode: () => string | undefined;
     getIP: () => string | undefined;
+    /** Host (and port) to send HTTP requests to - the IP address unless a range extender maps a port. */
+    getHttpEndpoint: () => string | undefined;
     /** Human-readable `ip (class / id / deviceId)` string for log messages. */
     getLogInfo: () => string;
     getDeviceId: () => string | undefined;

--- a/src/lib/devices/default.ts
+++ b/src/lib/devices/default.ts
@@ -144,7 +144,7 @@ const defaultsgen1: DeviceDefinition = {
             init_funct: self => self.getIP(),
         },
         mqtt: {
-            init_funct: self => self.getIP(),
+            init_funct: self => self.getHttpEndpoint(),
         },
         common: {
             name: 'Device IP address or hostname',
@@ -627,7 +627,7 @@ const defaultsgen2: DeviceDefinition = {
     },
     hostname: {
         mqtt: {
-            init_funct: self => self.getIP(),
+            init_funct: self => self.getHttpEndpoint(),
         },
         common: {
             name: 'Device IP address or hostname',

--- a/src/lib/protocol/base.ts
+++ b/src/lib/protocol/base.ts
@@ -46,6 +46,7 @@ export class BaseClient implements ShellyClient {
     http: Record<string, string[]>;
     deviceId: string | undefined; // e.g. SHBDUO-1#8CAAB5616291#2 (used in object IDs)
     ip: string | undefined; // e.g. 192.168.1.2
+    httpEndpoint: string | undefined; // e.g. 192.168.1.2 or 192.168.1.3:23456 (range extender NAT)
     id: string | undefined; // e.g. ShellyBulbDuo-8CAAB5616291
     deviceType: string | undefined; // e.g. SHBDUO-1 or SHRGBW2
     deviceMode: string | undefined; // e.g. color or white / relay or roller
@@ -90,10 +91,10 @@ export class BaseClient implements ShellyClient {
         }
 
         return new Promise((resolve, reject) => {
-            if (!this.getIP()) {
+            if (!this.getHttpEndpoint()) {
                 reject(
                     new Error(
-                        `[requestAsync] Unable to perform HTTP request "${url}" - IP address is unknown of ${this.getLogInfo()}`,
+                        `[requestAsync] Unable to perform HTTP request "${url}" - HTTP endpoint is unknown of ${this.getLogInfo()}`,
                     ),
                 );
                 return;
@@ -107,7 +108,7 @@ export class BaseClient implements ShellyClient {
                 transformResponse: (res: string) => {
                     return res; // Avoid automatic json parse
                 },
-                baseURL: `http://${this.getIP()}`,
+                baseURL: `http://${this.getHttpEndpoint()}`,
                 timeout: this.httpTimeout,
                 url,
             };
@@ -405,6 +406,43 @@ export class BaseClient implements ShellyClient {
         return this.ip;
     }
 
+    /**
+     * Returns the host (and port) HTTP requests have to go to.
+     * Same as the IP address unless the device sits behind a range extender.
+     *
+     * @returns
+     */
+    getHttpEndpoint(): string | undefined {
+        return this.httpEndpoint ?? this.ip;
+    }
+
+    clearHttpEndpoint(source: string): void {
+        if (!this.httpEndpoint) {
+            return;
+        }
+
+        this.adapter.log.debug(
+            `[clearHttpEndpoint] Removed HTTP endpoint for device ${this.getDeviceId()}: ${this.httpEndpoint} (source: ${source})`,
+        );
+        this.httpEndpoint = undefined;
+    }
+
+    async setHttpEndpoint(endpoint: string | undefined, source: string): Promise<void> {
+        if (!endpoint) {
+            return;
+        }
+
+        this.httpEndpoint = endpoint;
+        this.adapter.log.debug(
+            `[setHttpEndpoint] New HTTP endpoint for device ${this.getDeviceId()}: ${endpoint} (source: ${source})`,
+        );
+
+        const hostNameObj = await this.adapter.getObjectAsync(`${this.getDeviceId()}.hostname`);
+        if (hostNameObj) {
+            await this.adapter.setState(`${this.getDeviceId()}.hostname`, { val: endpoint, ack: true, c: source });
+        }
+    }
+
     async setIP(ip: string | undefined, source: string): Promise<void> {
         if (!ip) {
             return;
@@ -415,7 +453,11 @@ export class BaseClient implements ShellyClient {
 
         const hostNameObj = await this.adapter.getObjectAsync(`${this.getDeviceId()}.hostname`);
         if (hostNameObj) {
-            await this.adapter.setState(`${this.getDeviceId()}.hostname`, { val: ip, ack: true, c: source });
+            await this.adapter.setState(`${this.getDeviceId()}.hostname`, {
+                val: this.getHttpEndpoint(),
+                ack: true,
+                c: source,
+            });
         }
     }
 
@@ -437,7 +479,8 @@ export class BaseClient implements ShellyClient {
      * @returns
      */
     getLogInfo(): string {
-        return `${this.getIP() ?? ''} (${this.getDeviceClass()} / ${this.getId()} / ${this.getDeviceId()})`.trim();
+        const via = this.httpEndpoint && this.httpEndpoint !== this.ip ? ` via ${this.httpEndpoint}` : '';
+        return `${this.getIP() ?? ''}${via} (${this.getDeviceClass()} / ${this.getId()} / ${this.getDeviceId()})`.trim();
     }
 
     /**
@@ -518,9 +561,9 @@ export class BaseClient implements ShellyClient {
      * Missing data will be pulled by HTTP
      */
     async httpIoBrokerState(): Promise<void> {
-        if (!this.isOnline() || !this.getIP()) {
+        if (!this.isOnline() || !this.getHttpEndpoint()) {
             this.adapter.log.silly(
-                `[httpIoBrokerState] Device ${this.getLogInfo()} is offline (or IP is unknown) - waiting`,
+                `[httpIoBrokerState] Device ${this.getLogInfo()} is offline (or HTTP endpoint is unknown) - waiting`,
             );
 
             this.httpIoBrokerStateTimeout = setTimeout(
@@ -739,7 +782,9 @@ export class BaseClient implements ShellyClient {
                                     try {
                                         if (this.getDeviceGen() === 1) {
                                             // Append value parameters
-                                            const url = new URL(`http://${this.getIP()}${httpBlock?.http_cmd}`);
+                                            const url = new URL(
+                                                `http://${this.getHttpEndpoint()}${httpBlock?.http_cmd}`,
+                                            );
                                             if (typeof publishValue === 'object') {
                                                 Object.keys(publishValue).forEach(key =>
                                                     url.searchParams.append(key, publishValue[key]),
@@ -1070,6 +1115,7 @@ export class BaseClient implements ShellyClient {
 
         this.deviceId = undefined;
         this.ip = undefined;
+        this.httpEndpoint = undefined;
 
         this.id = undefined;
         this.deviceType = undefined;

--- a/src/lib/protocol/mqtt.ts
+++ b/src/lib/protocol/mqtt.ts
@@ -147,6 +147,17 @@ class MQTTClient extends BaseClient {
         return this.deviceId;
     }
 
+    /**
+     * Serial id reduced to plain lowercase hex, so it can be compared to a MAC address.
+     *
+     * @returns
+     */
+    getNormalizedSerialId(): string {
+        return this.getSerialId()
+            .replace(/[^a-fA-F0-9]/g, '')
+            .toLowerCase();
+    }
+
     getMqttPrefix(): string {
         return this.mqttprefix ?? '';
     }
@@ -257,6 +268,13 @@ class MQTTClient extends BaseClient {
                         // Update IP address
                         const ip = payloadObj?.result?.eth?.ip || payloadObj?.result?.wifi?.sta_ip;
                         if (ip && ip !== this.getIP()) {
+                            const remoteIp = this.stream?.remoteAddress;
+                            if (ip === remoteIp) {
+                                this.clearHttpEndpoint(`Gen 2+ ${INIT_SRC}/rpc`);
+                            } else if (remoteIp && !remoteIp.endsWith('.1')) {
+                                // TODO: remove workaround to skip in Docker env
+                                await this.setRangeExtenderHttpEndpoint(remoteIp);
+                            }
                             await this.setIP(ip, `Gen 2+ ${INIT_SRC}/rpc`);
                             await this.adapter.deviceStatusUpdate(this.getDeviceId(), true); // Device online
                         }
@@ -666,6 +684,59 @@ class MQTTClient extends BaseClient {
         return undefined;
     }
 
+    /**
+     * A Gen 2+ device connected through a range extender is reachable at the extender's
+     * address and a mapped port only. Ask every extender candidate that shares the remote
+     * address for its AP clients and pick the port belonging to this device.
+     *
+     * @param remoteIp address the MQTT connection of this device came from
+     * @returns whether an endpoint was found
+     */
+    async setRangeExtenderHttpEndpoint(remoteIp: string | null | undefined): Promise<boolean> {
+        if (this.getDeviceGen() < 2 || !remoteIp || !this.getNormalizedSerialId()) {
+            return false;
+        }
+
+        const clients = MQTTClient.clientlist ?? {};
+        for (const clientId in clients) {
+            const client = clients[clientId];
+            if (
+                !client ||
+                client === this ||
+                client.getDeviceGen() < 2 ||
+                client.getIP() !== remoteIp ||
+                !client.getHttpEndpoint()
+            ) {
+                continue;
+            }
+
+            try {
+                const body = await client.requestAsync('/rpc/WiFi.ListAPClients');
+                const apClients = JSON.parse(body)?.ap_clients ?? [];
+                const apClient = apClients.find(
+                    (entry: { mac?: string; mport?: number }) =>
+                        String(entry?.mac ?? '')
+                            .replace(/[^a-fA-F0-9]/g, '')
+                            .toLowerCase() === this.getNormalizedSerialId(),
+                );
+
+                if (apClient?.mport > 0) {
+                    await this.setHttpEndpoint(`${remoteIp}:${apClient.mport}`, `range extender ${client.getId()}`);
+                    this.adapter.log.info(
+                        `[MQTT] Device ${this.getId()} uses range extender ${client.getId()} via ${this.getHttpEndpoint()}`,
+                    );
+                    return true;
+                }
+            } catch (err) {
+                this.adapter.log.debug(
+                    `[MQTT] Unable to check range extender clients of ${client.getLogInfo()} for ${this.getLogInfo()}: ${err}`,
+                );
+            }
+        }
+
+        return false;
+    }
+
     listener(): void {
         // client connected
         this.client.on('connect', async packet => {
@@ -724,19 +795,13 @@ class MQTTClient extends BaseClient {
                     if (ip && !String(ip).endsWith('.1')) {
                         // TODO: remove workaround to skip in Docker env
                         await this.setIP(ip, 'MQTT connect');
+                        await this.setRangeExtenderHttpEndpoint(ip);
                     } else {
                         await this.initIPFromState();
                     }
 
                     this.adapter.log.silly(`[MQTT] Client id "${packet.clientId}" updating device status`);
                     await this.adapter.deviceStatusUpdate(this.getDeviceId(), true); // Device online
-
-                    this.adapter.log.silly(`[MQTT] Client id "${packet.clientId}" setting http states`);
-                    await this.httpIoBrokerState();
-
-                    if (this.isInitAborted('httpIoBrokerState')) {
-                        return;
-                    }
 
                     this.adapter.log.silly(`[MQTT] Client id "${packet.clientId}" setting mqtt prefix`);
                     if (this.will?.topic) {
@@ -792,6 +857,13 @@ class MQTTClient extends BaseClient {
                         this.adapter.log.debug(
                             `[MQTT] Client communication error (connack): "${packet.clientId}" - error: ${err}`,
                         );
+                    }
+
+                    this.adapter.log.silly(`[MQTT] Client id "${packet.clientId}" setting http states`);
+                    await this.httpIoBrokerState();
+
+                    if (this.isInitAborted('httpIoBrokerState')) {
+                        return;
                     }
 
                     this.adapter.log.info(`[MQTT] Device with client id "${packet.clientId}" initialized.`);

--- a/src/lib/shelly-helper.ts
+++ b/src/lib/shelly-helper.ts
@@ -432,8 +432,32 @@ async function getState(self: ShellyClient, id: string): Promise<ioBroker.StateV
     return state ? state.val : undefined;
 }
 
+/**
+ * Splits a hostname state into host and port. A device behind a range extender is
+ * stored as "address:port", everything else answers on port 80.
+ *
+ * @param hostname value of the hostname state
+ * @returns
+ */
+function parseHostnameWithPort(hostname: string): { hostname: string; port: number } {
+    try {
+        const url = new URL(`http://${hostname}`);
+
+        return {
+            hostname: url.hostname,
+            port: Number(url.port) || 80,
+        };
+    } catch {
+        return {
+            hostname,
+            port: 80,
+        };
+    }
+}
+
 export {
     getIcon,
+    parseHostnameWithPort,
     celsiusToFahrenheit,
     fahrenheitToCelsius,
     setDeviceName,

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import DeviceManagement from './lib/deviceManager';
 import ObjectHelper from './lib/objectHelper';
 import { CoAPServer } from './lib/protocol/coap';
 import { MQTTServer } from './lib/protocol/mqtt';
+import { parseHostnameWithPort } from './lib/shelly-helper';
 import type { ShellyAdapterConfig } from './lib/types';
 
 const adapterName = packageName.split('.').pop() ?? 'shelly';
@@ -261,8 +262,6 @@ export class ShellyAdapter extends Adapter {
      * Online-Check via TCP ping (when using CoAP)
      */
     private async onlineCheck(): Promise<void> {
-        const valPort = 80;
-
         if (this.onlineCheckTimeout) {
             this.clearTimeout(this.onlineCheckTimeout);
             this.onlineCheckTimeout = null;
@@ -275,9 +274,10 @@ export class ShellyAdapter extends Adapter {
                 const valHostname = stateHostName?.val;
 
                 if (valHostname) {
-                    this.log.debug(`[onlineCheck] Checking ${deviceId} on ${valHostname}:${valPort}`);
+                    const { hostname, port } = parseHostnameWithPort(String(valHostname));
+                    this.log.debug(`[onlineCheck] Checking ${deviceId} on ${hostname}:${port}`);
 
-                    tcpPing.probe(String(valHostname), valPort, (_error: Error | undefined, isAlive: boolean) =>
+                    tcpPing.probe(hostname, port, (_error: Error | undefined, isAlive: boolean) =>
                         this.deviceStatusUpdate(deviceId, isAlive),
                     );
                 }

--- a/test/shelly-helper.test.js
+++ b/test/shelly-helper.test.js
@@ -72,4 +72,19 @@ describe('Test Shelly Helper', function () {
         assert.strictEqual(shellyHelper.hextoInt('FF'), 255);
         assert.strictEqual(shellyHelper.hextoInt('FFF'), 4095);
     });
+    it('Test parseHostnameWithPort', function () {
+        assert.deepStrictEqual(shellyHelper.parseHostnameWithPort('192.168.1.2'), {
+            hostname: '192.168.1.2',
+            port: 80,
+        });
+        assert.deepStrictEqual(shellyHelper.parseHostnameWithPort('192.168.1.3:23456'), {
+            hostname: '192.168.1.3',
+            port: 23456,
+        });
+        assert.deepStrictEqual(shellyHelper.parseHostnameWithPort('shellyplus1pm-44179394d4d4'), {
+            hostname: 'shellyplus1pm-44179394d4d4',
+            port: 80,
+        });
+        assert.deepStrictEqual(shellyHelper.parseHostnameWithPort(''), { hostname: '', port: 80 });
+    });
 });


### PR DESCRIPTION
Replaces #1528, which was opened before the TypeScript migration and cannot be rebased: it changed `lib/protocol/base.js`, `lib/protocol/mqtt.js`, `lib/devices/default.js` and `main.js`, and none of those files exist anymore. The change is ported to `src/**` here, on top of current master.

### Summary

A Gen 2+ device connected through a Shelly Range Extender reports its own WLAN address over MQTT, but HTTP requests never reach it there - the extender NATs it and only the extender's address plus a mapped port works. Polling, the `http_cmd` control path and the online check all used the reported IP and failed.

- `httpEndpoint` is kept apart from `ip` on the client. `getHttpEndpoint()` falls back to `ip`, so nothing changes for a device that is not behind an extender
- When the remote address of the MQTT connection differs from the IP the device reports, every other Gen 2+ client sharing that remote address is asked for `WiFi.ListAPClients`. The entry whose MAC matches this device's serial id yields `mport`, and the endpoint becomes `<extender-ip>:<mport>`
- `Shelly.GetDeviceInfo` clears the endpoint again as soon as the device reports the address it is actually reachable at, so a device moved back to the router recovers on its own
- `httpIoBrokerState()` now runs at the end of the connect handler. Before, the first HTTP poll went out before the endpoint was resolved
- The `hostname` state carries the endpoint, so the online check reaches the device too. `parseHostnameWithPort()` splits `address:port` back apart and answers port 80 for everything else
- `getLogInfo()` appends ` via <endpoint>` when the two differ, so the log shows which device sits behind which extender

### Notes on the port from #1528

Three things were added on top of the original change:

- `httpEndpoint` and `getHttpEndpoint` had to be declared in the `ShellyClient` interface (`src/lib/deviceTypes.ts`), otherwise `default.ts` does not compile
- The Gen 1 `http_cmd` path in `base.ts` still built its URL from `getIP()`. Same defect, different caller - it is fixed along with the rest
- `parseHostnameWithPort()` lives in `src/lib/shelly-helper.ts` instead of being private to the adapter class, so it can be covered by a test

The note in the README is narrowed rather than dropped: Gen 1 devices behind a range extender are still unsupported.

### Testing

- Tested with a Shelly Outdoor Plug S Gen3 connected through a Shelly Plus 1PM range extender: MQTT state updates, control commands, and HTTP polling over the mapped `AP-IP:mport` endpoint
- `npm run check`
- `npm run lint`
- `npm run test:js` - 32 passing, including the new `parseHostnameWithPort` case
- `npm run test:package` - 57 passing
