### PR TITLE
fix: authenticate Gen2+ devices up front to reduce firmware 2.x 429 (refers to #1543)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
 -->
 ### **WORK IN PROGRESS**
 - (@mcm1957) Fixed authentication with Gen2+ devices running firmware 2.x which could fail with "Wrong http username or http password!" although the credentials were correct. [#1543]
+- (@mcm1957) Gen2+ devices are now authenticated up front by reusing the last valid login, which reduces the "Too Many Requests" rejections seen with firmware 2.x. [#1543]
 
 ### 12.0.0-alpha.6 (2026-09-09)
 - (@mcm1957) **BREAKING:** Adapter requires js-controller >= 7.7.2 and admin >= 8.0.11 now.

--- a/src/lib/protocol/base.ts
+++ b/src/lib/protocol/base.ts
@@ -55,6 +55,8 @@ export class BaseClient implements ShellyClient {
     serialId: string | undefined; // e.g. 8CAAB5616291
     deviceGen: number | undefined; // 1 or 2
     nonceCount: number;
+    /** Last digest challenge (realm/nonce) that authenticated successfully, reused pre-emptively. */
+    digestChallenge: Record<string, string> | null;
     httpTimeout: number;
 
     constructor(type: 'mqtt' | 'coap', adapter: ShellyAdapter, objectHelper: ObjectHelper, eventEmitter: EventEmitter) {
@@ -73,6 +75,7 @@ export class BaseClient implements ShellyClient {
         this.http = {};
 
         this.nonceCount = 0;
+        this.digestChallenge = null;
         this.httpTimeout = 8 * 1000;
 
         // Handle firmware updates
@@ -190,9 +193,20 @@ export class BaseClient implements ShellyClient {
 
                 // Send the request; on a 401 digest challenge (re)compute the Authorization header and
                 // retry. Firmware 2.x manages nonces per RFC 7616 and may answer an authenticated request
-                // with "401 stale=true" once a nonce expires - in that case retry once with the fresh nonce
+                // with "401 stale=true" once a nonce expires - in that case retry with the fresh nonce
                 // instead of treating it as a credential error.
-                const attempt = (config: AxiosRequestConfig, staleRetriesLeft: number): void => {
+                //
+                // `challengeAuthed` is true once the Authorization was derived from a live challenge of the
+                // current request. A header derived from a cached challenge does not count: if the device
+                // rejects it (expired/unknown nonce) we simply re-challenge instead of reporting a
+                // credential error. Caching the last working challenge lets us authenticate the first
+                // request pre-emptively, which avoids the extra unauthenticated round-trip that otherwise
+                // triggers the firmware 2.x brute-force protection ("429 Too Many Requests").
+                const attempt = (
+                    config: AxiosRequestConfig,
+                    staleRetriesLeft: number,
+                    challengeAuthed: boolean,
+                ): void => {
                     axios(config)
                         .then(response => {
                             this.adapter.log.silly(
@@ -209,27 +223,37 @@ export class BaseClient implements ShellyClient {
                                 return;
                             }
 
-                            const wasAuthenticated = !!(config.headers as Record<string, string> | undefined)
-                                ?.Authorization;
                             const authDetails = this.parseDigestChallenge(wwwAuthenticate as string);
                             const isStale = String(authDetails.stale).toLowerCase() === 'true';
 
-                            // Already authenticated and the device still rejects with a non-stale nonce
-                            // -> genuine credential error. Also stop once the stale retries are exhausted.
-                            if (wasAuthenticated && (!isStale || staleRetriesLeft <= 0)) {
+                            // Already authenticated against a live challenge and still rejected with a
+                            // non-stale nonce -> genuine credential error. Also stop once the stale retries
+                            // are exhausted. Drop the cached challenge so we re-challenge next time.
+                            if (challengeAuthed && (!isStale || staleRetriesLeft <= 0)) {
+                                this.digestChallenge = null;
                                 reject(err instanceof Error ? err : new Error(String(err)));
                                 return;
                             }
 
+                            // Remember the working challenge so subsequent requests can authenticate up front.
+                            this.digestChallenge = authDetails;
                             const authorization = this.buildDigestAuthHeader(authDetails, method, url);
                             attempt(
                                 { ...axiosRequestObj, headers: { Authorization: authorization } },
-                                wasAuthenticated ? staleRetriesLeft - 1 : staleRetriesLeft,
+                                challengeAuthed ? staleRetriesLeft - 1 : staleRetriesLeft,
+                                true,
                             );
                         });
                 };
 
-                attempt(axiosRequestObj, 1);
+                if (this.digestChallenge) {
+                    // Authenticate pre-emptively with the last known-good challenge; if the nonce is no
+                    // longer accepted the catch handler falls back to a normal challenge/response.
+                    const authorization = this.buildDigestAuthHeader(this.digestChallenge, method, url);
+                    attempt({ ...axiosRequestObj, headers: { Authorization: authorization } }, 1, false);
+                } else {
+                    attempt(axiosRequestObj, 1, false);
+                }
             }
         });
     }


### PR DESCRIPTION
## What

Reduces the `429 Too Many Requests` rejections seen with Gen2+ Shelly devices on firmware 2.x by authenticating the first request up front instead of always starting unauthenticated. refers to #1543

> **Stacked on #1588.** This PR targets `fix/1543-gen2-digest-nonce` (the nonce-parsing / stale-retry fix), which it builds on. Please merge #1588 first; GitHub will then retarget this PR to `master` automatically. Review only the last commit here.

## Why

Every Gen2+ request previously sent an unauthenticated request purely to provoke a digest challenge, then retried with credentials. Firmware 2.x added brute-force protection, and that steady stream of unauthenticated requests is a source of the intermittent `429 Too Many Requests` reported in the issue.

## How

In `src/lib/protocol/base.ts`:

- Added a per-client `digestChallenge` cache holding the last `realm`/`nonce` that authenticated successfully.
- When a cached challenge exists, the first request is sent **pre-emptively authenticated** (reusing the nonce with an incremented `nc`, per RFC 7616).
- If the device rejects the cached nonce (expired/unknown), the client falls back to the normal challenge/response flow — so correctness is unchanged. The `challengeAuthed` flag distinguishes a cache-derived header (rejection ⇒ re-challenge) from a live-challenge header (non-stale rejection ⇒ genuine credential error). A credential error clears the cache.

## Reviewer notes

- No new unauthenticated round-trip once the cache is warm; a cold start still does one challenge exchange as before.
- `npm run check`, `eslint`, `npm run build` pass. `npm run test:js`: 32 passing; the 2 failures are pre-existing in `ble-gateway-script.test.js` (docs↔script CRLF mismatch on a Windows checkout) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)