### PR TITLE
feat: add support for Neo Smart Water Valve NAS-WV02W

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Notes:
 | FrankEver Smart Watervalve (watervalve)                    | ❌   | >= v10.6.0 |
 | HiluX DS8 by Shelly (hiluxds8)                             | ❌   | >= v11.0.0 |
 | LinkedGo Smart Thermost (st1820)                           | ❌   | >= v10.6.0 |
+| Neo Smart Water Valve NAS-WV02W (neowatervalve)            | ❌   | >= v12.0.0 |
 | Ogemray 25A (ogemray25a)                                   | ❌   | >= v9.5.0  |
 | Shelly Cury (cury)                                         | ❌   | >= v11.0.0 |
 | Top AC Portable EV Charger (topacportableevcharger) (1)(*) | ❌   | >= v12.0.0 |
@@ -229,6 +230,9 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (@mcm1957) Added support for Neo Smart Water Valve NAS-WV02W (neowatervalve). [#1322]
+
 ### 12.0.0-alpha.6 (2026-09-09)
 - (@mcm1957) **BREAKING:** Adapter requires js-controller >= 7.7.2 and admin >= 8.0.11 now.
 - (@mcm1957) Added missing translations for the adapter configuration. [#1586]

--- a/src/lib/datapoints.ts
+++ b/src/lib/datapoints.ts
@@ -114,6 +114,7 @@ import { shellypstripg4 } from './devices/gen4/shellypstripg4';
 import { cury } from './devices/poweredbyshelly/cury';
 import { hiluxds8 } from './devices/poweredbyshelly/hiluxds8';
 import { irrigation } from './devices/poweredbyshelly/irrigation';
+import { neowatervalve } from './devices/poweredbyshelly/neowatervalve';
 import { ogemray25a } from './devices/poweredbyshelly/ogemray25a';
 import { st1820 } from './devices/poweredbyshelly/st1820';
 import { topacportableevcharger } from './devices/poweredbyshelly/topacportableevcharger';
@@ -232,6 +233,7 @@ const devices: Record<string, DeviceDefinition> = {
     cury,
     hiluxds8,
     irrigation,
+    neowatervalve,
     ogemray25a,
     st1820,
     topacportableevcharger,
@@ -351,6 +353,7 @@ const deviceGen: Record<string, number> = {
     cury: 3,
     hiluxds8: 3,
     irrigation: 3,
+    neowatervalve: 3,
     ogemray25a: 3,
     st1820: 3,
     topacportableevcharger: 3,
@@ -471,6 +474,7 @@ const deviceGroupMap: Record<string, string> = {
     cury: 'other',
     hiluxds8: 'light',
     irrigation: 'other',
+    neowatervalve: 'other',
     ogemray25a: 'other',
     st1820: 'other',
     topacportableevcharger: 'other',
@@ -590,6 +594,7 @@ const deviceIcons: Record<string, string> = {
     cury: 'cury',
     hiluxds8: 'shellyprorgbwwpm',
     irrigation: 'shellyplus1',
+    neowatervalve: 'shellyplus1',
     ogemray25a: 'shellyplus1',
     st1820: 'shellyplus1',
     topacportableevcharger: 'shellyplus1',
@@ -710,6 +715,7 @@ const deviceKnowledgeBase: Record<string, string | undefined> = {
     cury: 'https://kb.shelly.cloud/knowledge-base/cury',
     hiluxds8: undefined, // no knowledgebase entry exists
     irrigation: undefined, // no knowledgebase entry exists
+    neowatervalve: 'https://www.shelly.com/blogs/documentation/neo-smart-water-valve',
     ogemray25a: 'https://www.shelly.com/de/products/ogemray-25a-smart-relay',
     st1820: undefined, // no knowledgebase entry exists,
     topacportableevcharger: undefined, // no knowledgebase entry exists,
@@ -831,6 +837,7 @@ const deviceTypes: Record<string, string[]> = {
     cury: ['cury'],
     hiluxds8: ['hiluxds8'],
     irrigation: ['irrigation'],
+    neowatervalve: ['neowatervalve'],
     ogemray25a: ['ogemray25a'],
     st1820: ['st1820'],
     topacportableevcharger: ['topacportableevcharger'],

--- a/src/lib/devices/poweredbyshelly/neowatervalve.ts
+++ b/src/lib/devices/poweredbyshelly/neowatervalve.ts
@@ -1,0 +1,30 @@
+import type { DeviceDefinition } from '../../deviceTypes';
+import * as shellyHelperVirtual from '../virtual-helper';
+
+/**
+ * SHELLY_??? / neowatervalve
+ * Neo Smart Water Valve NAS-WV02W
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyX/XT1/SmartWaterValve
+ * https://www.shelly.com/de/products/neo-smart-water-valve-nas-wv02w
+ * https://www.shelly.com/blogs/documentation/neo-smart-water-valve
+ *
+ * Component log see https://github.com/iobroker-community-adapters/ioBroker.shelly/issues/1322#issuecomment-4405971916
+ *
+ */
+
+const neowatervalve: DeviceDefinition = {};
+
+// boolean:200 - State (valve closed/open)
+shellyHelperVirtual.addBoolean(neowatervalve, 200, 'crw', {});
+
+// number:200 - Flow rate
+shellyHelperVirtual.addNumber(neowatervalve, 200, 'cr', { unit: 'm3/min', min: 0, max: 0.075 });
+
+// number:201 - Water pressure
+shellyHelperVirtual.addNumber(neowatervalve, 201, 'cr', { unit: 'kPa', min: 0, max: 1350 });
+
+// number:202 - Water temperature
+shellyHelperVirtual.addNumber(neowatervalve, 202, 'cr', { unit: '°C', min: -25, max: 80 });
+
+export { neowatervalve };


### PR DESCRIPTION
@
## Summary

Adds support for the **Neo Smart Water Valve NAS-WV02W** (`neowatervalve`), a Powered-by-Shelly Gen2+ device that exposes its data via virtual components over MQTT.

Component definitions are based on the `Shelly.GetComponents` output posted in the issue. Only existing standard virtual-component helpers are used (no new component types):

- `boolean:200` → State (valve open/close, read + write)
- `number:200` → Flow rate (m³/min)
- `number:201` → Water pressure (kPa)
- `number:202` → Water temperature (°C)

The `object:200` (water consumption counter) component is not included, as there is no existing virtual `Object` component helper; this can be added in a follow-up if needed.

## Changes
- New device file `src/lib/devices/poweredbyshelly/neowatervalve.ts`
- Registered `neowatervalve` in all tables of `src/lib/datapoints.ts`
- Added the device to the supported-devices table and a changelog entry in `README.md`

## Testing
- `npm run check`, `npm run build`, and datapoints unit tests pass.

refers to #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@