### PR TITLE
feat: add support for FrankEver Smart Sprinkler Controller (irrigation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Notes:
 
 | Device                                                     | CoAP | MQTT       |
 |------------------------------------------------------------| ---- | ---------- |
+| FrankEver Smart Sprinkler Controller (irrigation) (*)      | ❌   | >= v12.0.0 |
 | FrankEver Smart Watervalve (watervalve)                    | ❌   | >= v10.6.0 |
 | HiluX DS8 by Shelly (hiluxds8)                             | ❌   | >= v11.0.0 |
 | LinkedGo Smart Thermost (st1820)                           | ❌   | >= v10.6.0 |
@@ -212,7 +213,6 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
 - USB-powered UVC LED strip
 - Shelly Wall Display X2
 - Shelly LoRa Add-On
-- Shelly Frankever Smart Sprinkler Controller (irrigation) (*)
 
 - Shelly BLU TRV
 - all BLU devices that need to receive data from the adapter.
@@ -229,6 +229,9 @@ See [documentation (en)](https://github.com/iobroker-community-adapters/ioBroker
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (@mcm1957) Added experimental support for FrankEver Smart Sprinkler Controller (irrigation). [#1207]
+
 ### 12.0.0-alpha.6 (2026-09-09)
 - (@mcm1957) **BREAKING:** Adapter requires js-controller >= 7.7.2 and admin >= 8.0.11 now.
 - (@mcm1957) Added missing translations for the adapter configuration. [#1586]

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "Richtungen ÖFFNEN und SCHLIESSEN tauschen",
     "target illuminance": "Zielbeleuchtungsstärke",
     "target state": "Zielzustand",
-    "unknown": "unbekannt"
+    "unknown": "unbekannt",
+    "Average temperature": "Durchschnittstemperatur",
+    "Precipitation in the last 24 hours": "Niederschlag der letzten 24 Stunden",
+    "Active irrigation sequence": "Aktive Bewässerungssequenz",
+    "Enable zone irrigation": "Bewässerung der Zone aktivieren",
+    "Watering duration": "Bewässerungsdauer",
+    "Started at": "Gestartet um",
+    "Command source": "Befehlsquelle"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "swap OPEN and CLOSE directions",
     "target illuminance": "target illuminance",
     "target state": "target state",
-    "unknown": "unknown"
+    "unknown": "unknown",
+    "Average temperature": "Average temperature",
+    "Precipitation in the last 24 hours": "Precipitation in the last 24 hours",
+    "Active irrigation sequence": "Active irrigation sequence",
+    "Enable zone irrigation": "Enable zone irrigation",
+    "Watering duration": "Watering duration",
+    "Started at": "Started at",
+    "Command source": "Command source"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "Intercambiar direcciones ABRIR y CERRAR",
     "target illuminance": "iluminancia del objetivo",
     "target state": "estado objetivo",
-    "unknown": "desconocido"
+    "unknown": "desconocido",
+    "Average temperature": "Temperatura media",
+    "Precipitation in the last 24 hours": "Precipitación en las últimas 24 horas",
+    "Active irrigation sequence": "Secuencia de riego activa",
+    "Enable zone irrigation": "Activar riego de zona",
+    "Watering duration": "Duración del riego",
+    "Started at": "Iniciado a las",
+    "Command source": "Origen del comando"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "Inverser les directions OUVRIR et FERMER",
     "target illuminance": "éclairement cible",
     "target state": "état cible",
-    "unknown": "inconnu"
+    "unknown": "inconnu",
+    "Average temperature": "Température moyenne",
+    "Precipitation in the last 24 hours": "Précipitations des dernières 24 heures",
+    "Active irrigation sequence": "Séquence d'irrigation active",
+    "Enable zone irrigation": "Activer l'irrigation de la zone",
+    "Watering duration": "Durée d'arrosage",
+    "Started at": "Démarré à",
+    "Command source": "Source de la commande"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "Scambia direzioni APRI e CHIUDI",
     "target illuminance": "illuminamento target",
     "target state": "stato di destinazione",
-    "unknown": "sconosciuto"
+    "unknown": "sconosciuto",
+    "Average temperature": "Temperatura media",
+    "Precipitation in the last 24 hours": "Precipitazioni nelle ultime 24 ore",
+    "Active irrigation sequence": "Sequenza di irrigazione attiva",
+    "Enable zone irrigation": "Attiva irrigazione della zona",
+    "Watering duration": "Durata dell'irrigazione",
+    "Started at": "Avviato alle",
+    "Command source": "Origine del comando"
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "OPEN- en DICHT-richtingen omwisselen",
     "target illuminance": "doelverlichtingssterkte",
     "target state": "doelstatus",
-    "unknown": "onbekend"
+    "unknown": "onbekend",
+    "Average temperature": "Gemiddelde temperatuur",
+    "Precipitation in the last 24 hours": "Neerslag in de laatste 24 uur",
+    "Active irrigation sequence": "Actieve irrigatiesequentie",
+    "Enable zone irrigation": "Zone-irrigatie inschakelen",
+    "Watering duration": "Bewateringsduur",
+    "Started at": "Gestart om",
+    "Command source": "Opdrachtbron"
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "Zamień kierunki OTWÓRZ i ZAMKNIJ",
     "target illuminance": "docelowe natężenie oświetlenia",
     "target state": "stan docelowy",
-    "unknown": "nieznany"
+    "unknown": "nieznany",
+    "Average temperature": "Średnia temperatura",
+    "Precipitation in the last 24 hours": "Opady w ciągu ostatnich 24 godzin",
+    "Active irrigation sequence": "Aktywna sekwencja nawadniania",
+    "Enable zone irrigation": "Włącz nawadnianie strefy",
+    "Watering duration": "Czas podlewania",
+    "Started at": "Rozpoczęto o",
+    "Command source": "Źródło polecenia"
 }

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "Trocar direções ABRIR e FECHAR",
     "target illuminance": "iluminância alvo",
     "target state": "estado alvo",
-    "unknown": "desconhecido"
+    "unknown": "desconhecido",
+    "Average temperature": "Temperatura média",
+    "Precipitation in the last 24 hours": "Precipitação nas últimas 24 horas",
+    "Active irrigation sequence": "Sequência de irrigação ativa",
+    "Enable zone irrigation": "Ativar irrigação da zona",
+    "Watering duration": "Duração da rega",
+    "Started at": "Iniciado às",
+    "Command source": "Origem do comando"
 }

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "Поменять направления ОТКРЫТЬ и ЗАКРЫТЬ",
     "target illuminance": "целевая освещенность",
     "target state": "целевое состояние",
-    "unknown": "неизвестный"
+    "unknown": "неизвестный",
+    "Average temperature": "Средняя температура",
+    "Precipitation in the last 24 hours": "Осадки за последние 24 часа",
+    "Active irrigation sequence": "Активная последовательность полива",
+    "Enable zone irrigation": "Включить полив зоны",
+    "Watering duration": "Длительность полива",
+    "Started at": "Запущено в",
+    "Command source": "Источник команды"
 }

--- a/src/i18n/uk.json
+++ b/src/i18n/uk.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "Поміняти напрямки ВІДКРИТИ і ЗАКРИТИ",
     "target illuminance": "освітленість цілі",
     "target state": "цільовий стан",
-    "unknown": "невідомий"
+    "unknown": "невідомий",
+    "Average temperature": "Середня температура",
+    "Precipitation in the last 24 hours": "Опади за останні 24 години",
+    "Active irrigation sequence": "Активна послідовність поливу",
+    "Enable zone irrigation": "Увімкнути полив зони",
+    "Watering duration": "Тривалість поливу",
+    "Started at": "Запущено о",
+    "Command source": "Джерело команди"
 }

--- a/src/i18n/zh-cn.json
+++ b/src/i18n/zh-cn.json
@@ -426,5 +426,12 @@
     "swap OPEN and CLOSE directions": "交换 打开 和 关闭 方向",
     "target illuminance": "目标照度",
     "target state": "目标状态",
-    "unknown": "未知"
+    "unknown": "未知",
+    "Average temperature": "平均温度",
+    "Precipitation in the last 24 hours": "过去24小时降水量",
+    "Active irrigation sequence": "当前灌溉序列",
+    "Enable zone irrigation": "启用区域灌溉",
+    "Watering duration": "浇水时长",
+    "Started at": "开始于",
+    "Command source": "命令来源"
 }

--- a/src/lib/devices/poweredbyshelly/irrigation.ts
+++ b/src/lib/devices/poweredbyshelly/irrigation.ts
@@ -110,10 +110,7 @@ for (let zoneId = 0; zoneId <= 5; zoneId++) {
     const startedAtState: DeviceState = {
         mqtt: {
             http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="zones_status"',
-            http_publish_funct: value => {
-                const startedAt = value ? JSON.parse(value).value[`zone${zoneId}`]?.started_at : undefined;
-                return startedAt ? startedAt * 1000 : undefined;
-            },
+            http_publish_funct: value => (value ? JSON.parse(value).value[`zone${zoneId}`]?.started_at : undefined),
         },
         common: {
             name: 'Started at',

--- a/src/lib/devices/poweredbyshelly/irrigation.ts
+++ b/src/lib/devices/poweredbyshelly/irrigation.ts
@@ -1,19 +1,147 @@
-import type { DeviceDefinition } from '../../deviceTypes';
-// import * as shellyHelperGen2 from '../gen2-helper';
+import type { DeviceDefinition, DeviceState } from '../../deviceTypes';
 
 /**
- * SHELLY_PBS_ST_ST1820 / irrigation
- * Shelly Frankever Smart Sprinkler Controller
+ * Frankever Smart Sprinkler Controller / irrigation
  *
- * https://shelly-api-docs.shelly.cloud/ - not available -
- * https://www.shelly.com/de/blogs/documentation/ - not available -
+ * Shelly XT1 based irrigation controller (product code S3XT-0S).
+ * The device does not report a device type, so 'irrigation' is used as deviceId
+ * (client-id reported by the device is e.g. 'irrigation-b08184ee0488').
  *
+ * The irrigation functionality is provided by an XMOD service (owner "service:0")
+ * exposing typed virtual components (Boolean/Number/Enum/Object) per role.
+ *
+ * https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyX/XT1/IrrigationController
+ * https://www.shelly.com/products/frankever-smart-sprinkler-controller-fk-06x
  */
 
-// NOTE: This is only a temporary basic implemention to aid gathering more information
+const irrigation: DeviceDefinition = {
+    'Irrigation.AverageTemperature': {
+        mqtt: {
+            http_publish: '/rpc/Number.GetStatus?owner="service:0"&role="average_temperature"',
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+        },
+        common: {
+            name: 'Average temperature',
+            type: 'number',
+            role: 'value.temperature',
+            unit: '°C',
+            read: true,
+            write: false,
+        },
+    },
+    'Irrigation.LastPrecipitation': {
+        mqtt: {
+            http_publish: '/rpc/Number.GetStatus?owner="service:0"&role="last_precipitation"',
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+        },
+        common: {
+            name: 'Precipitation in the last 24 hours',
+            type: 'number',
+            role: 'value',
+            unit: 'mm/m²',
+            read: true,
+            write: false,
+        },
+    },
+    'Irrigation.ActiveSequence': {
+        mqtt: {
+            http_publish: '/rpc/Enum.GetStatus?owner="service:0"&role="active_sequence"',
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Enum.Set',
+                    params: { owner: 'service:0', role: 'active_sequence', value: value },
+                });
+            },
+        },
+        common: {
+            name: 'Active irrigation sequence',
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: true,
+        },
+    },
+};
 
-const irrigation: DeviceDefinition = {};
+// Zones 0..5: enable switch plus status information (duration/started_at/source)
+for (let zoneId = 0; zoneId <= 5; zoneId++) {
+    const enableState: DeviceState = {
+        mqtt: {
+            http_publish: `/rpc/Boolean.GetStatus?owner="service:0"&role="zone${zoneId}"`,
+            http_publish_funct: value => (value ? JSON.parse(value).value : undefined),
+            mqtt_cmd: '<mqttprefix>/rpc',
+            mqtt_cmd_funct: (value, self) => {
+                return JSON.stringify({
+                    id: self.getNextMsgId(),
+                    src: 'iobroker',
+                    method: 'Boolean.Set',
+                    params: { owner: 'service:0', role: `zone${zoneId}`, value: value },
+                });
+            },
+        },
+        common: {
+            name: 'Enable zone irrigation',
+            type: 'boolean',
+            role: 'switch',
+            read: true,
+            write: true,
+        },
+    };
 
-// shellyHelperGen2.xxxx(st1820, 0); ### information currently missing ###
+    const durationState: DeviceState = {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="zones_status"',
+            http_publish_funct: value => (value ? JSON.parse(value).value[`zone${zoneId}`]?.duration : undefined),
+        },
+        common: {
+            name: 'Watering duration',
+            type: 'number',
+            role: 'value',
+            unit: 'min',
+            read: true,
+            write: false,
+        },
+    };
+
+    const startedAtState: DeviceState = {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="zones_status"',
+            http_publish_funct: value => {
+                const startedAt = value ? JSON.parse(value).value[`zone${zoneId}`]?.started_at : undefined;
+                return startedAt ? startedAt * 1000 : undefined;
+            },
+        },
+        common: {
+            name: 'Started at',
+            type: 'number',
+            role: 'date',
+            read: true,
+            write: false,
+        },
+    };
+
+    const sourceState: DeviceState = {
+        mqtt: {
+            http_publish: '/rpc/Object.GetStatus?owner="service:0"&role="zones_status"',
+            http_publish_funct: value => (value ? JSON.parse(value).value[`zone${zoneId}`]?.source : undefined),
+        },
+        common: {
+            name: 'Command source',
+            type: 'string',
+            role: 'text',
+            read: true,
+            write: false,
+        },
+    };
+
+    irrigation[`Zone${zoneId}.Enable`] = enableState;
+    irrigation[`Zone${zoneId}.Duration`] = durationState;
+    irrigation[`Zone${zoneId}.StartedAt`] = startedAtState;
+    irrigation[`Zone${zoneId}.Source`] = sourceState;
+}
 
 export { irrigation };


### PR DESCRIPTION
Implements support for the **FrankEver Smart Sprinkler Controller** (Shelly XT1 based, product code `S3XT-0S`, client-id e.g. `irrigation-b08184ee0488`), replacing the previous dummy definition.

The irrigation functionality is provided through the XMOD service (`owner:"service:0"`) with typed virtual-component roles, following the same pattern as the sibling XT1 device `topacportableevcharger`.

### States
- `Irrigation.AverageTemperature` (°C, weather API) — read
- `Irrigation.LastPrecipitation` (mm/m², last 24h) — read
- `Irrigation.ActiveSequence` (`seq_<n>`) — read/write via `Enum.Set`
- `Zone0..Zone5.Enable` — read/write via `Boolean.Set` (roles `zone0..zone5`)
- `Zone0..Zone5.Duration` (min) / `.StartedAt` / `.Source` — read, parsed from the `zones_status` object. `StartedAt` uses `role: 'date'` and stores the raw epoch-seconds timestamp, consistent with the existing `gen2-helper` timer fields.

Standard Gen2+ system states are added automatically by the base client.

### Other changes
- Added the 7 new state-name keys to all 11 `src/i18n/*.json` language files.
- README: moved the device from *NOT Supported* into the *Powered By Shelly* table (experimental) and added a changelog entry.

### Notes
- Based on the [official XT1 Irrigation Controller API docs](https://shelly-api-docs.shelly.cloud/gen2/Devices/ShellyX/XT1/IrrigationController) and the MQTT logs in the issue. The device reported only the standard system components in the captured logs (no active zones), so the zone/sequence control paths are documented but unverified — hence marked experimental.

refers to #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
